### PR TITLE
Execute a single command where single quotes are needed.

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -115,6 +115,15 @@ func (p *Pipe) Exec(s string) *Pipe {
 	q := NewPipe()
 	args := strings.Fields(s)
 	cmd := exec.Command(args[0], args[1:]...)
+
+	// Check if the command contains a single quote.
+	// such as "bash -c 'echo 10'"
+	if strings.Contains(s, "'") {
+		first := strings.Index(s, "'")
+		last := strings.LastIndex(s, "'")
+		cmd = exec.Command(args[0], args[1], s[first:last+1])
+	}
+
 	cmd.Stdin = p.Reader
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/filters.go
+++ b/filters.go
@@ -113,16 +113,17 @@ func (p *Pipe) Exec(s string) *Pipe {
 		return p
 	}
 	q := NewPipe()
+	var first int
 	args := strings.Fields(s)
-	cmd := exec.Command(args[0], args[1:]...)
 
 	// Check if the command contains a single quote.
-	// such as "bash -c 'echo 10'"
 	if strings.Contains(s, "'") {
-		first := strings.Index(s, "'")
-		last := strings.LastIndex(s, "'")
-		cmd = exec.Command(args[0], args[1], s[first:last+1])
+		first = strings.Index(s, "'")
+		args = strings.Fields(s[0:first])
+		args = append(args, s[first:])
 	}
+
+	cmd := exec.Command(args[0], args[1:]...)
 
 	cmd.Stdin = p.Reader
 	output, err := cmd.CombinedOutput()

--- a/filters_test.go
+++ b/filters_test.go
@@ -189,6 +189,27 @@ func TestExecFilter(t *testing.T) {
 	if out != "" {
 		t.Error("want exec on erroneous pipe to be a no-op, but it wasn't")
 	}
+
+	// Testing cases with double quotes wrapped in single quoutes.
+	testPipe := NewPipe()
+	testQuotes := []struct {
+		testStrings string
+		want        string
+	}{
+		{`echo 'test'`, "test"},
+		{`echo "a 'b c' d"`, `a 'b c' d`},
+		{`bash -c "echo 'test two'"`, `test two`},
+	}
+	for _, tc := range testQuotes {
+		p = testPipe.Exec(tc.testStrings)
+		got, err = p.String()
+		if err != nil {
+			t.Error(err)
+		}
+		if got != tc.want {
+			t.Errorf("Testing single quotes:\nwant %q, got %q", tc.want, got)
+		}
+	}
 }
 
 func TestJoin(t *testing.T) {


### PR DESCRIPTION
This is in response to issue #32 where the user wanted to enter a command where they specified the shell.

eg. `bash -c 'echo testing'`.

This fix will not handle a command with trailing `&&` at this time but after looking at the readme it seems that may not be the proper use case anyway.

eg. `bash -c 'echo testing' && echo again`