### PR TITLE
Fix Exec to handle quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ fmt.Println(output)
 `Exec()` runs a given command and creates a pipe containing its combined output (`stdout` and `stderr`). If there was an error running the command, the pipe's error status will be set.
 
 ```go
-p := script.Exec("echo hello")
+p := script.Exec("bash -c 'echo hello'")
 output, err := p.String()
 fmt.Println(output)
 // Output: hello
@@ -811,6 +811,7 @@ Since `script` is designed to help you write system administration programs, a f
 
 * [cat](examples/cat/main.go) (copies stdin to stdout)
 * [cat 2](examples/cat2/main.go) (takes a list of files on the command line and concatenates their contents to stdout)
+* [execute](examples/execute/main.go)
 * [grep](examples/grep/main.go)
 * [head](examples/head/main.go)
 * [echo](examples/echo/main.go)

--- a/examples/execute/main.go
+++ b/examples/execute/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/bitfield/script"
+)
+
+func main() {
+	script.Exec("bash -c 'echo hello world'").Stdout()
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/bitfield/script
 
 go 1.12
 
-require github.com/google/go-cmp v0.3.1
+require (
+	bitbucket.org/creachadair/shell v0.0.6
+	github.com/google/go-cmp v0.3.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+bitbucket.org/creachadair/shell v0.0.6 h1:reJflDbKqnlnqb4Oo2pQ1/BqmY/eCWcNGHrIUO8qIzc=
+bitbucket.org/creachadair/shell v0.0.6/go.mod h1:8Qqi/cYk7vPnsOePHroKXDJYmb5x7ENhtiFtfZq8K+M=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/sources_test.go
+++ b/sources_test.go
@@ -51,22 +51,40 @@ func TestExec(t *testing.T) {
 		WantOutputContain string
 	}{
 		{
-			Command:           "go",
-			ErrExpected:       true,
-			WantErrContain:    "exit status 2",
-			WantOutputContain: "Usage",
-		},
-		{
 			Command:           "doesntexist",
 			ErrExpected:       true,
 			WantErrContain:    "file not found",
 			WantOutputContain: "",
 		},
 		{
+			Command:           "go",
+			ErrExpected:       true,
+			WantErrContain:    "exit status 2",
+			WantOutputContain: "Usage",
+		},
+		{
 			Command:           "go help",
 			ErrExpected:       false,
 			WantErrContain:    "",
 			WantOutputContain: "Usage",
+		},
+		{
+			Command:           "sh -c 'echo hello'",
+			ErrExpected:       false,
+			WantErrContain:    "",
+			WantOutputContain: "hello\n",
+		},
+		{
+			Command:           "sh -c 'echo oh no",
+			ErrExpected:       true,
+			WantErrContain:    "",
+			WantOutputContain: "",
+		},
+		{
+			Command:           "sh -c 'sh -c \"echo inception\"'",
+			ErrExpected:       false,
+			WantErrContain:    "",
+			WantOutputContain: "inception\n",
 		},
 	}
 	for _, tc := range tcs {


### PR DESCRIPTION
Issue #32 highlighted a problem with the simple approach (`strings.Fields`) to splitting a command string into a suitable slice of strings for `exec.Command`. A program like this:

```go
p := script.Exec("bash -c 'docker ps'")
```

didn't work as expected, because the actual slice of strings passed to the command was:

```go
{"bash", "-c", "'docker", "ps'"}
```

which causes the shell to choke. We need a slightly smarter approach which takes into account quoted strings, and doesn't split them:

```
{"bash", "-c", "docker ps"}
```

The [creachadair/shell](https://bitbucket.org/creachadair/shell) library provides a facility (`Split`) to do exactly this. Thanks to @shumin1027 for the original report, @posener for input, and @jrswab for an initial draft PR on this.
