### PR TITLE
fix SHA256Sum

### DIFF
--- a/sinks.go
+++ b/sinks.go
@@ -54,14 +54,13 @@ func (p *Pipe) SHA256Sum() (string, error) {
 		return "", p.Error()
 	}
 
-	bytes, err := p.Bytes()
-	if err != nil {
+	h := sha256.New()
+	if _, err := io.Copy(h, p.Reader); err != nil {
 		p.SetError(err)
 		return "", p.Error()
 	}
 
-	sum := sha256.Sum256(bytes)
-	encodedCheckSum := hex.EncodeToString(sum[:])
+	encodedCheckSum := hex.EncodeToString(h.Sum(nil)[:])
 	return encodedCheckSum, nil
 }
 


### PR DESCRIPTION
Hi :wave:

This is a fix for https://github.com/bitfield/script/issues/49
According to the docs, here is how the hash functions should be used: https://golang.org/pkg/crypto/sha256/#New
Here is the same test (hashing a 1GB file) with the fix applied:
```
root@ef78500374de:/workspaces/script# go test
PASS
ok      github.com/bitfield/script      3.748s
```

IMHO there should be a `sinks.CheckSum(hash.Hash)` method instead. This way you could hash files with any algorithm you like. A checksum doesn't have to be cryptographically secure as mentioned https://github.com/bitfield/script/issues/39#issuecomment-598124476, it's just a way to verify a file's integrity. People often share MD5 hashes because they're less CPU intensive to compute.