### PR TITLE
Trim newlines from file paths

### DIFF
--- a/sources.go
+++ b/sources.go
@@ -34,6 +34,7 @@ func Exec(s string) *Pipe {
 // status will be set, and if the file does exist, the pipe will have no error
 // status.
 func IfExists(filename string) *Pipe {
+	filename = strings.TrimRight(filename, "\n")
 	_, err := os.Stat(filename)
 	if err != nil {
 		return NewPipe().WithError(err)
@@ -45,6 +46,7 @@ func IfExists(filename string) *Pipe {
 // starting pipelines. If there is an error opening the file, the pipe's error
 // status will be set.
 func File(name string) *Pipe {
+	name = strings.TrimRight(name, "\n")
 	p := NewPipe()
 	f, err := os.Open(name)
 	if err != nil {
@@ -58,6 +60,7 @@ func File(name string) *Pipe {
 // `find -type f`. If the path doesn't exist or can't be read, the pipe's error
 // status will be set.
 func FindFiles(path string) *Pipe {
+	path = strings.TrimRight(path, "\n")
 	var fileNames []string
 	walkFn := func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -78,6 +81,7 @@ func FindFiles(path string) *Pipe {
 // supplied path, one per line. The path may be a glob, conforming to
 // filepath.Match syntax.
 func ListFiles(path string) *Pipe {
+	path = strings.TrimRight(path, "\n")
 	if strings.ContainsAny(path, "[]^*?\\{}!") {
 		fileNames, err := filepath.Glob(path)
 		if err != nil {

--- a/sources_test.go
+++ b/sources_test.go
@@ -111,7 +111,7 @@ func TestFile(t *testing.T) {
 	t.Parallel()
 	wantRaw, _ := ioutil.ReadFile("testdata/test.txt") // ignoring error
 	want := string(wantRaw)
-	p := File("testdata/test.txt")
+	p := File("testdata/test.txt\n") // file paths retrieved through Pipe.String() contain a trailing newline
 	gotRaw, err := ioutil.ReadAll(p.Reader)
 	if err != nil {
 		t.Error(err)
@@ -134,7 +134,7 @@ func TestFindFiles(t *testing.T) {
 		Want           string
 	}{
 		{
-			Path:        "testdata/multiple_files",
+			Path:        "testdata/multiple_files\n", // file paths retrieved through Pipe.String() contain a trailing newline
 			ErrExpected: false,
 			Want:        "testdata/multiple_files/1.txt\ntestdata/multiple_files/2.txt\ntestdata/multiple_files/3.tar.zip\n",
 		},
@@ -173,7 +173,7 @@ func TestIfExists(t *testing.T) {
 	if p.Error() == nil {
 		t.Errorf("want error from IfExists on non-existent file, but got nil")
 	}
-	p = IfExists("testdata/empty.txt")
+	p = IfExists("testdata/empty.txt\n") // file paths retrieved through Pipe.String() contain a trailing newline
 	if p.Error() != nil {
 		t.Errorf("want no error from IfExists on existing file, but got %v", p.Error())
 	}
@@ -202,7 +202,7 @@ func TestListFilesNonexistent(t *testing.T) {
 
 func TestListFilesSingle(t *testing.T) {
 	t.Parallel()
-	got, err := ListFiles("testdata/multiple_files/1.txt").String()
+	got, err := ListFiles("testdata/multiple_files/1.txt\n").String() // file paths retrieved through Pipe.String() contain a trailing newline
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Hi @bitfield , as discussed, I created a fix for issue #62 . 
Improvement: all functions taking a file path as input trim any trailing newline off the input string. This helps avoiding errors or the need of manual newline removal when the file path is a result of ListFiles() or FindFiles() (that always return a newline-delimited string).
I changed existing tests to receive paths with a trailing newline. 

Possible points to discuss:
* Instead of changing the existing test cases, separate test cases could be added to test with and without trailing newlines. On the other hand, the "without trailing newlines" case is already covered, as a newline is stripped anyway.
* Instead of just trimming trailing newlines, would trimming all leading and trailing whitespace from file paths make sense? Would there be a use case for that?