### PR TITLE
Add ExternalFilter filter to enable the user to write custom filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ examples/visitors/visitors
 examples/*/go.sum
 .vscode/settings.json
 examples/ls/ls
+.idea

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ John is also the author of the popular [For the Love of Go](https://bitfieldcons
 	- [EachLine](#eachline)
 	- [Exec](#exec-1)
 	- [ExecForEach](#execforeach)
+	- [ExternalFilter](#externalfilter)
 	- [First](#first)
 	- [Freq](#freq)
 	- [Join](#join)
@@ -616,6 +617,30 @@ The first command which results in an error will set the pipe's error status acc
 // Execute all PHP files in current directory and print output
 script.ListFiles("*.php").ExecForEach("php {{.}}").Stdout()
 ```
+
+## ExternalFilter
+
+ExternalFilter runs the given filter functions on the current pipe. This filter can be used to include custom filters in
+a pipe. The external filter function must handle a nil pipe.
+```go
+func secondLine(in *script.Pipe) *script.Pipe {
+	if in == nil {
+		return nil
+    }
+	scanner := bufio.NewScanner(in)
+	var count = 0
+	for scanner.Scan() {
+		count++
+		if count == 2 {
+			return script.Echo(string(scanner.Bytes()))
+		}
+	}
+	return script.NewPipe().WithError(errors.New("no second line"))
+}
+// List all PHP files in current directory and print the second file on stdout output
+script.ListFiles("*.php").ExternalFilter(secondLine).Stdout()
+```
+
 
 ## First
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ John is also the author of the popular [For the Love of Go](https://bitfieldcons
 	- [EachLine](#eachline)
 	- [Exec](#exec-1)
 	- [ExecForEach](#execforeach)
-	- [ExternalFilter](#externalfilter)
+	- [FilterFunc](#filterfunc)
 	- [First](#first)
 	- [Freq](#freq)
 	- [Join](#join)
@@ -618,10 +618,10 @@ The first command which results in an error will set the pipe's error status acc
 script.ListFiles("*.php").ExecForEach("php {{.}}").Stdout()
 ```
 
-## ExternalFilter
+## FilterFunc
 
-ExternalFilter runs the given filter functions on the current pipe. This filter can be used to include custom filters in
-a pipe. The external filter function must handle a nil pipe.
+FilterFunc runs the given filter functions on the current pipe. This filter can be used to include custom filters in
+a pipe. The filter function must handle a nil pipe.
 ```go
 func secondLine(in *script.Pipe) *script.Pipe {
 	if in == nil {
@@ -638,7 +638,7 @@ func secondLine(in *script.Pipe) *script.Pipe {
 	return script.NewPipe().WithError(errors.New("no second line"))
 }
 // List all PHP files in current directory and print the second file on stdout output
-script.ListFiles("*.php").ExternalFilter(secondLine).Stdout()
+script.ListFiles("*.php").FilterFunc(secondLine).Stdout()
 ```
 
 

--- a/examples/external_filter/main.go
+++ b/examples/external_filter/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"github.com/bitfield/script"
+)
+
+// This program prints out the names of every second files in the current directory.
+
+func everySecond(in *script.Pipe) *script.Pipe {
+	out := bytes.NewBuffer(nil)
+	scanner := bufio.NewScanner(in)
+	var count = 0
+	for scanner.Scan() {
+		if count%2 == 0 {
+			out.Write(scanner.Bytes())
+			out.WriteString("\n")
+		}
+		count++
+	}
+	p := script.NewPipe().WithReader(out)
+	if err := scanner.Err(); err != nil {
+		p = p.WithError(err)
+	}
+	return p
+}
+
+func main() {
+	script.ListFiles("*").ExternalFilter(everySecond).Stdout()
+}

--- a/examples/external_filter/main.go
+++ b/examples/external_filter/main.go
@@ -27,5 +27,5 @@ func everySecond(in *script.Pipe) *script.Pipe {
 }
 
 func main() {
-	script.ListFiles("*").ExternalFilter(everySecond).Stdout()
+	script.ListFiles("*").FilterFunc(everySecond).Stdout()
 }

--- a/filters.go
+++ b/filters.go
@@ -386,9 +386,9 @@ func (p *Pipe) SHA256Sums() *Pipe {
 	})
 }
 
-// ExternalFilter calls the given filter function with the current active Pipe. If the filter is nil, the current pipe
+// FilterFunc calls the given filter function with the current active Pipe. If the filter is nil, the current pipe
 // is returned. Hence it will effectively be a NOOP. The filter function must handle nil Pipes as input.
-func (p *Pipe) ExternalFilter(filter func(in *Pipe) *Pipe) *Pipe {
+func (p *Pipe) FilterFunc(filter func(in *Pipe) *Pipe) *Pipe {
 	if filter == nil {
 		return p
 	}

--- a/filters.go
+++ b/filters.go
@@ -385,3 +385,12 @@ func (p *Pipe) SHA256Sums() *Pipe {
 		out.WriteRune('\n')
 	})
 }
+
+// ExternalFilter calls the given filter function with the current active Pipe. If the filter is nil, the current pipe
+// is returned. Hence it will effectively be a NOOP. The filter function must handle nil Pipes as input.
+func (p *Pipe) ExternalFilter(filter func(in *Pipe) *Pipe) *Pipe {
+	if filter == nil {
+		return p
+	}
+	return filter(p)
+}

--- a/filters_test.go
+++ b/filters_test.go
@@ -484,3 +484,35 @@ func TestSHA256Sums(t *testing.T) {
 		}
 	}
 }
+
+func TestExternalFilter(t *testing.T) {
+	t.Parallel()
+	p := NewPipe()
+	after := p.ExternalFilter(nil)
+	if p != after {
+		t.Errorf("Nil-Filter: want %v, got %v", p, after)
+	}
+	if err := after.Error(); err != nil {
+		t.Errorf("Nil-Filter: got error: %v, expected nil", err)
+	}
+	expect := "foo"
+	constFilter := func(in *Pipe) *Pipe {
+		return Echo(expect)
+	}
+	data, err := NewPipe().ExternalFilter(constFilter).String()
+	if err != nil {
+		t.Errorf("Const-Filter: got error: %v, expected nil", err)
+	}
+	if data != expect {
+		t.Errorf("Const-Filter: want %v, got %v", expect, data)
+	}
+	expectErr := errors.New("some error")
+	errFilter := func(in *Pipe) *Pipe {
+		return NewPipe().WithError(expectErr)
+	}
+	err = NewPipe().ExternalFilter(errFilter).Error()
+	if err != expectErr {
+		t.Errorf("Error-Filter: want %v, got %v", expectErr, err)
+
+	}
+}

--- a/filters_test.go
+++ b/filters_test.go
@@ -485,10 +485,10 @@ func TestSHA256Sums(t *testing.T) {
 	}
 }
 
-func TestExternalFilter(t *testing.T) {
+func TestFilterFunc(t *testing.T) {
 	t.Parallel()
 	p := NewPipe()
-	after := p.ExternalFilter(nil)
+	after := p.FilterFunc(nil)
 	if p != after {
 		t.Errorf("Nil-Filter: want %v, got %v", p, after)
 	}
@@ -499,7 +499,7 @@ func TestExternalFilter(t *testing.T) {
 	constFilter := func(in *Pipe) *Pipe {
 		return Echo(expect)
 	}
-	data, err := NewPipe().ExternalFilter(constFilter).String()
+	data, err := NewPipe().FilterFunc(constFilter).String()
 	if err != nil {
 		t.Errorf("Const-Filter: got error: %v, expected nil", err)
 	}
@@ -510,7 +510,7 @@ func TestExternalFilter(t *testing.T) {
 	errFilter := func(in *Pipe) *Pipe {
 		return NewPipe().WithError(expectErr)
 	}
-	err = NewPipe().ExternalFilter(errFilter).Error()
+	err = NewPipe().FilterFunc(errFilter).Error()
 	if err != expectErr {
 		t.Errorf("Error-Filter: want %v, got %v", expectErr, err)
 

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -156,8 +156,8 @@ func doMethodsOnPipe(t *testing.T, p *Pipe, kind string) {
 	p.WithReader(strings.NewReader(""))
 	action = "WriteFile()"
 	p.WriteFile("testdata/bogus.txt")
-	action = "ExternalFilter()"
-	p.ExternalFilter(func(in *Pipe) *Pipe {
+	action = "FilterFunc()"
+	p.FilterFunc(func(in *Pipe) *Pipe {
 		return in
 	})
 }

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -156,6 +156,10 @@ func doMethodsOnPipe(t *testing.T, p *Pipe, kind string) {
 	p.WithReader(strings.NewReader(""))
 	action = "WriteFile()"
 	p.WriteFile("testdata/bogus.txt")
+	action = "ExternalFilter()"
+	p.ExternalFilter(func(in *Pipe) *Pipe {
+		return in
+	})
 }
 
 func TestNilPipes(t *testing.T) {


### PR DESCRIPTION
This enables the user to write own filters and use them in the fluent interface of the Pipe without forking the core library.

Implement the ExternalFilter function as discussed in #74 