### PR TITLE
pipeline streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,15 @@ fmt.Println(err)
 // Output: read test.txt: file already closed
 ```
 
+## Wait
+
+`Wait()` waits until the pipe finishes, consumes it, and returns the error:
+
+```go
+err := script.Slice(make([]string, 5)).ExecForEach("sleep 1").Wait()
+// should sleep for 5 seconds
+```
+
 ## WriteFile
 
 `WriteFile()` writes the contents of the pipe to a named file. It returns the number of bytes written, or an error:

--- a/examples/stream/main.go
+++ b/examples/stream/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/bitfield/script"
+)
+
+// This program runs tests on the script library 50 times and prints out the progress nicely.
+
+func main() {
+	round, step := 10, 5
+	progressInfo := make([]string, round)
+	for i := 0; i < round; i++ {
+		progressInfo[i] = fmt.Sprintf("------ Done %v / %v ------", (i+1)*step, round*step)
+	}
+	cmd := fmt.Sprintf("bash -c 'go test -count %v github.com/bitfield/script; echo {{.}}'", step)
+	// with Stream(), the program can print to stdout in real time
+	script.Slice(progressInfo).Stream().ExecForEach(cmd).Stdout()
+}

--- a/filters.go
+++ b/filters.go
@@ -109,15 +109,20 @@ func (p *Pipe) EachLine(process func(string, *strings.Builder)) *Pipe {
 			output := strings.Builder{}
 			process(scanner.Text(), &output)
 			if p.Error() != nil {
-				q.SetError(p.Error())
 				break
 			}
 			w.Write([]byte(output.String()))
 		}
-		err := scanner.Err()
+		// by this time, the previous pipe stage must have finished
+		err := p.Error()
 		if err != nil {
-			p.SetError(err)
 			q.SetError(err)
+		} else {
+			err := scanner.Err()
+			if err != nil {
+				p.SetError(err)
+				q.SetError(err)
+			}
 		}
 		w.Close()
 	}()

--- a/filters.go
+++ b/filters.go
@@ -444,3 +444,25 @@ func (p *Pipe) SHA256Sums() *Pipe {
 		out.WriteRune('\n')
 	})
 }
+
+// Stream lets the pipeline after it be executed in the streaming mode.
+// Like a Unix pipe, functions start simultaneously, each consuming the
+// output of its predecessor instantly. Function will stop when it detects
+// an error either in itself or from its predecessor. One can call
+// Synchronize() or any sink function to disable the streaming.
+func (p *Pipe) Stream() *Pipe {
+	if p == nil {
+		return p
+	}
+	return p.withAsync(true)
+}
+
+// Synchronize turns off streaming mode
+func (p *Pipe) Synchronize() *Pipe {
+	if p == nil || p.Error() != nil || !p.async {
+		return p
+	}
+	w := bytes.Buffer{}
+	io.Copy(&w, p.Reader)
+	return NewPipe().WithReader(bytes.NewReader(w.Bytes())).withAsync(false)
+}

--- a/filters.go
+++ b/filters.go
@@ -180,27 +180,14 @@ func (p *Pipe) ExecForEach(cmdTpl string) *Pipe {
 // lines. If there is an error reading the pipe, the pipe's error status is also
 // set.
 func (p *Pipe) First(lines int) *Pipe {
-	if p == nil || p.Error() != nil {
-		return p
-	}
-	defer p.Close()
-	if lines == 0 {
-		return NewPipe()
-	}
-	scanner := bufio.NewScanner(p.Reader)
-	output := strings.Builder{}
-	for i := 0; i < lines; i++ {
-		if !scanner.Scan() {
-			break
+	count := 0
+	return p.EachLine(func(s string, b *strings.Builder) {
+		if count < lines {
+			b.WriteString(s)
+			b.WriteRune('\n')
 		}
-		output.WriteString(scanner.Text())
-		output.WriteRune('\n')
-	}
-	err := scanner.Err()
-	if err != nil {
-		p.SetError(err)
-	}
-	return Echo(output.String())
+		count++
+	})
 }
 
 // Freq reads from the pipe, and returns a new pipe containing only unique lines

--- a/filters_test.go
+++ b/filters_test.go
@@ -184,14 +184,9 @@ func TestExecForEach(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.Command, func(t *testing.T) {
-			p := Slice(tc.Input).ExecForEach(tc.Command)
-			if tc.ErrExpected != (p.Error() != nil) {
-				t.Fatalf("unexpected error value: %v", p.Error())
-			}
-			p.SetError(nil) // else p.String() would be a no-op
-			output, err := p.String()
-			if err != nil {
-				t.Fatalf("unexpected error %v", err)
+			output, err := Slice(tc.Input).ExecForEach(tc.Command).String()
+			if tc.ErrExpected != (err != nil) {
+				t.Fatalf("unexpected error value: %v", err)
 			}
 			if !strings.Contains(output, tc.WantOutput) {
 				t.Fatalf("want output %q to contain %q", output, tc.WantOutput)

--- a/filters_test.go
+++ b/filters_test.go
@@ -192,6 +192,18 @@ func TestExecFilter(t *testing.T) {
 	if out != "" {
 		t.Error("want exec on erroneous pipe to be a no-op, but it wasn't")
 	}
+
+	payload := make([]string, 30)
+	payload[0] = " do_not_print_this"
+	payload[20] = "bogus"
+	p = Slice(payload).ExecForEach("echo{{.}}")
+	out, err = p.Exec("cat").String()
+	if out != "" {
+		t.Error("want exec on erroneous pipe to be a no-op, but it wasn't")
+	}
+	if !strings.Contains(err.Error(), "echobogus") {
+		t.Errorf("error %q does not contain 'echobogus'", err)
+	}
 }
 
 func TestExecForEach(t *testing.T) {

--- a/pipes.go
+++ b/pipes.go
@@ -10,11 +10,12 @@ import (
 type Pipe struct {
 	Reader ReadAutoCloser
 	err    error
+	async  bool
 }
 
-// NewPipe returns a pointer to a new empty pipe.
+// NewPipe returns a pointer to a new empty pipe, with streaming turned off.
 func NewPipe() *Pipe {
-	return &Pipe{ReadAutoCloser{}, nil}
+	return &Pipe{ReadAutoCloser{}, nil, false}
 }
 
 // Close closes the pipe's associated reader. This is always safe to do, because
@@ -89,5 +90,12 @@ func (p *Pipe) WithReader(r io.Reader) *Pipe {
 // modified pipe.
 func (p *Pipe) WithError(err error) *Pipe {
 	p.SetError(err)
+	return p
+}
+
+// WithError sets the pipe's error status to the specified error and returns the
+// modified pipe.
+func (p *Pipe) withAsync(async bool) *Pipe {
+	p.async = async
 	return p
 }

--- a/pipes.go
+++ b/pipes.go
@@ -41,10 +41,11 @@ var exitStatusPattern = regexp.MustCompile(`exit status (\d+)$`)
 // pipe's error status is set, and if the error matches the pattern "exit status
 // %d". Otherwise, it returns zero.
 func (p *Pipe) ExitStatus() int {
-	if p.Error() == nil {
+	perr := p.Error()
+	if perr == nil {
 		return 0
 	}
-	match := exitStatusPattern.FindStringSubmatch(p.Error().Error())
+	match := exitStatusPattern.FindStringSubmatch(perr.Error())
 	if len(match) < 2 {
 		return 0
 	}

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -148,8 +148,12 @@ func doMethodsOnPipe(t *testing.T, p *Pipe, kind string) {
 	stdoutM.Lock()
 	defer stdoutM.Unlock()
 	p.Stdout()
+	action = "Stream()"
+	p.Stream()
 	action = "String()"
 	p.String()
+	action = "Synchronize()"
+	p.Synchronize()
 	action = "WithError()"
 	p.WithError(nil)
 	action = "WithReader()"

--- a/sinks.go
+++ b/sinks.go
@@ -103,7 +103,7 @@ func (p *Pipe) String() (string, error) {
 	return string(data), nil
 }
 
-// Wait blocks until the previous Pipe finishes
+// Wait blocks until the previous Pipe finishes, and returns the error
 func (p *Pipe) Wait() error {
 	if p == nil || p.Error() != nil || !p.async {
 		return p.Error()

--- a/sinks.go
+++ b/sinks.go
@@ -105,7 +105,7 @@ func (p *Pipe) String() (string, error) {
 
 // Wait blocks until the previous Pipe finishes
 func (p *Pipe) Wait() error {
-	if p == nil || p.Error() != nil {
+	if p == nil || p.Error() != nil || !p.async {
 		return p.Error()
 	}
 	_, err := ioutil.ReadAll(p.Reader)

--- a/sources.go
+++ b/sources.go
@@ -113,3 +113,12 @@ func Slice(s []string) *Pipe {
 func Stdin() *Pipe {
 	return NewPipe().WithReader(os.Stdin)
 }
+
+// Stream lets the pipeline after it be executed in the streaming mode.
+// Like a Unix pipe, functions start simultaneously, each consuming the
+// output of its predecessor instantly. Function will stop when it detects
+// an error either in itself or from its predecessor. One can call
+// Synchronize() or any sink function to disable the streaming.
+func Stream() *Pipe {
+	return NewPipe().withAsync(true)
+}

--- a/sources_test.go
+++ b/sources_test.go
@@ -89,18 +89,14 @@ func TestExec(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.Command, func(t *testing.T) {
 			p := Exec(tc.Command)
-			if tc.ErrExpected != (p.Error() != nil) {
-				t.Fatalf("unexpected error value: %v", p.Error())
-			}
-			if p.Error() != nil && !strings.Contains(p.Error().Error(), tc.WantErrContain) {
-				t.Fatalf("want error string %q to contain %q", p.Error().Error(), tc.WantErrContain)
-			}
-			p.SetError(nil) // else p.String() would be a no-op
 			output, err := p.String()
-			if err != nil {
-				t.Fatalf("unexpected error %v", err)
+			if tc.ErrExpected != (err != nil) {
+				t.Fatalf("unexpected error value: %v", err)
 			}
-			if !strings.Contains(output, tc.WantOutputContain) {
+			if err != nil && !strings.Contains(err.Error(), tc.WantErrContain) {
+				t.Fatalf("want error string %q to contain %q", err.Error(), tc.WantErrContain)
+			}
+			if err == nil && !strings.Contains(output, tc.WantOutputContain) {
 				t.Fatalf("want output %q to contain %q", output, tc.WantOutputContain)
 			}
 		})


### PR DESCRIPTION
This PR is an attempt to tackle issue #34. I used io.Pipe() in the `EachLine()` to implement streaming, which is simple and efficient.

As an example, the following program outputs 'toc' five times, with one second time interval:
```go
script.Slice(make([]string, 5)).ExecForEach("bash -c 'echo tic; sleep 1'").Replace("tic", "toc").Stdout()
```

Unluckily, the program is not backward compatible. A user must append a Sink method at the end of the pipeline if s/he wants to wait until the program finishes. For this reason, I added a Wait() method, and slightly modified the test for `ExecForEach()`. (The code passed all other tests.) Another problem is that the `strings.Builder` in `EachLine()` cannot be reset, since the stream is append only.
Currently, Error() and ExitStatus() return the intermediate status of a running pipe, since they are not Sink methods.

Probably, one solution is to add a bool flag in the `Pipe` struct to enable/disable streaming. (Disabled by default & use a Stream() source method to enable it). Should I go ahead?

