### PR TITLE
Bug fixes and improvements for corner cases

### DIFF
--- a/filters_test.go
+++ b/filters_test.go
@@ -51,6 +51,27 @@ func TestColumn(t *testing.T) {
 	if !bytes.Equal(got, want) {
 		t.Errorf("want %q, got %q", want, got)
 	}
+	got, err = script.File("testdata/column.input.txt").Column(0).Bytes()
+	if err != nil {
+		t.Error()
+	}
+	if !bytes.Equal(got, []byte{}) {
+		t.Errorf("want %q, got %q", want, got)
+	}
+	got, err = script.File("testdata/column.input.txt").Column(-1).Bytes()
+	if err != nil {
+		t.Error()
+	}
+	if !bytes.Equal(got, []byte{}) {
+		t.Errorf("want %q, got %q", want, got)
+	}
+	got, err = script.File("testdata/column.input.txt").Column(10).Bytes()
+	if err != nil {
+		t.Error()
+	}
+	if !bytes.Equal(got, []byte{}) {
+		t.Errorf("want %q, got %q", want, got)
+	}
 }
 
 func TestConcat(t *testing.T) {
@@ -232,6 +253,18 @@ func TestFirst(t *testing.T) {
 	if err == nil {
 		t.Error("input not closed after reading")
 	}
+	input = script.File("testdata/first.input.txt")
+	gotZero, err = input.First(-1).CountLines()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotZero != 0 {
+		t.Errorf("want 0 lines, got %d lines", gotZero)
+	}
+	_, err = ioutil.ReadAll(input.Reader)
+	if err == nil {
+		t.Error("input not closed after reading")
+	}
 	want, err = script.File("testdata/first.input.txt").Bytes()
 	if err != nil {
 		t.Fatal(err)
@@ -312,6 +345,18 @@ func TestLast(t *testing.T) {
 	if err == nil {
 		t.Error("input not closed after reading")
 	}
+	input = script.File("testdata/first.input.txt")
+	gotZero, err = input.Last(-1).CountLines()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotZero != 0 {
+		t.Errorf("want 0 lines, got %d lines", gotZero)
+	}
+	_, err = ioutil.ReadAll(input.Reader)
+	if err == nil {
+		t.Error("input not closed after reading")
+	}
 	want, err = script.File("testdata/first.input.txt").Bytes()
 	if err != nil {
 		t.Fatal(err)
@@ -350,6 +395,16 @@ func TestMatch(t *testing.T) {
 
 func TestMatchRegexp(t *testing.T) {
 	t.Parallel()
+	p := script.File("testdata/hello.txt")
+	_, err := p.MatchRegexp(nil).String()
+	if err == nil {
+		t.Error("nil regex should cause an error")
+	}
+	_, err = ioutil.ReadAll(p.Reader)
+	if err == nil {
+		t.Error("input not closed after reading")
+	}
+
 	testCases := []struct {
 		testFileName string
 		match        string
@@ -397,6 +452,16 @@ func TestReplace(t *testing.T) {
 
 func TestReplaceRegexp(t *testing.T) {
 	t.Parallel()
+	p := script.File("testdata/hello.txt")
+	_, err := p.ReplaceRegexp(nil, "").String()
+	if err == nil {
+		t.Error("nil regex should cause an error")
+	}
+	_, err = ioutil.ReadAll(p.Reader)
+	if err == nil {
+		t.Error("input not closed after reading")
+	}
+
 	testCases := []struct {
 		testFileName string
 		regexp       string
@@ -444,6 +509,16 @@ func TestReject(t *testing.T) {
 
 func TestRejectRegexp(t *testing.T) {
 	t.Parallel()
+	p := script.File("testdata/hello.txt")
+	_, err := p.RejectRegexp(nil).String()
+	if err == nil {
+		t.Error("nil regex should cause an error")
+	}
+	_, err = ioutil.ReadAll(p.Reader)
+	if err == nil {
+		t.Error("input not closed after reading")
+	}
+
 	testCases := []struct {
 		testFileName string
 		reject       string

--- a/pipes.go
+++ b/pipes.go
@@ -75,6 +75,9 @@ func (p *Pipe) Read(b []byte) (int, error) {
 // SetError sets the pipe's error status to the specified error.
 func (p *Pipe) SetError(err error) {
 	if p != nil {
+		if err != nil {
+			p.Close()
+		}
 		p.err = err
 	}
 }

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -25,6 +25,23 @@ func TestWithReader(t *testing.T) {
 		t.Errorf("want %q, got %q", want, got)
 	}
 }
+func TestWithError(t *testing.T) {
+	p := File("testdata/empty.txt")
+	want := "fake error"
+	_, gotErr := p.WithError(errors.New(want)).String()
+	if gotErr.Error() != "fake error" {
+		t.Errorf("want %q, got %q", want, gotErr.Error())
+	}
+	_, err := ioutil.ReadAll(p.Reader)
+	if err == nil {
+		t.Error("input not closed after reading")
+	}
+	p = File("testdata/empty.txt")
+	_, gotErr = p.WithError(nil).String()
+	if gotErr != nil {
+		t.Errorf("got unexpected error: %q", gotErr.Error())
+	}
+}
 
 func TestWithStdout(t *testing.T) {
 	t.Parallel()
@@ -126,6 +143,8 @@ func doMethodsOnPipe(t *testing.T, p *script.Pipe, kind string) {
 	p.Error()
 	action = "Exec()"
 	p.Exec("bogus")
+	action = "ExecForEach()"
+	p.ExecForEach("bogus")
 	action = "ExitStatus()"
 	p.ExitStatus()
 	action = "First()"
@@ -142,6 +161,10 @@ func doMethodsOnPipe(t *testing.T, p *script.Pipe, kind string) {
 	p.MatchRegexp(regexp.MustCompile(".*"))
 	action = "Read()"
 	p.Read([]byte{})
+	action = "Reject()"
+	p.Reject("")
+	action = "RejectRegexp"
+	p.RejectRegexp(regexp.MustCompile(".*"))
 	action = "Replace()"
 	p.Replace("old", "new")
 	action = "ReplaceRegexp()"

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -179,6 +179,8 @@ func doMethodsOnPipe(t *testing.T, p *script.Pipe, kind string) {
 	p.Slice()
 	action = "Stdout()"
 	p.Stdout()
+	q := &Pipe{}
+	q.Stdout()
 	action = "String()"
 	p.String()
 	action = "WithError()"

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -179,8 +179,6 @@ func doMethodsOnPipe(t *testing.T, p *script.Pipe, kind string) {
 	p.Slice()
 	action = "Stdout()"
 	p.Stdout()
-	q := &Pipe{}
-	q.Stdout()
 	action = "String()"
 	p.String()
 	action = "WithError()"

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -25,8 +25,10 @@ func TestWithReader(t *testing.T) {
 		t.Errorf("want %q, got %q", want, got)
 	}
 }
+
 func TestWithError(t *testing.T) {
-	p := File("testdata/empty.txt")
+	t.Parallel()
+	p := script.File("testdata/empty.txt")
 	want := "fake error"
 	_, gotErr := p.WithError(errors.New(want)).String()
 	if gotErr.Error() != "fake error" {
@@ -36,7 +38,7 @@ func TestWithError(t *testing.T) {
 	if err == nil {
 		t.Error("input not closed after reading")
 	}
-	p = File("testdata/empty.txt")
+	p = script.File("testdata/empty.txt")
 	_, gotErr = p.WithError(nil).String()
 	if gotErr != nil {
 		t.Errorf("got unexpected error: %q", gotErr.Error())

--- a/testdata/freq.golden.txt
+++ b/testdata/freq.golden.txt
@@ -1,4 +1,4 @@
 10 apple
  4 banana
- 2 orange
+ 4 orange
  1 kumquat

--- a/testdata/freq.input.txt
+++ b/testdata/freq.input.txt
@@ -6,11 +6,13 @@ apple
 orange
 kumquat
 apple
+orange
 apple
 banana
 banana
 apple
 apple
+orange
 apple
 apple
 apple


### PR DESCRIPTION
When working on #88 , I noticed some defects in the current library, so I'd like to submit this separate patch, which does the following: 

**Fix the defect that Column() crashes on zero or a negative input**
The library panics when the following code is run
```go
script.Echo("1").Column(-1)
```
After the change, the program will return an empty pipe.

**Fix the defect that Last() crashes on a negative input**
The library panics when the following code is run
```go
script.Echo("1").Last(-1)
```
After the change, the program will return an empty pipe.

**Fix the defect that Regex filters crash on a nil regex expression**
The library panics when the following code is run
```go
script.Echo("1").MatchRegexp(nil)
```
After the change, the program will return a pipe with the error "nil regular expression"

**Add unit test for WithError(); close the pipe when a non-nil error is set**
When fixing the regex defect, I just wrote
```go
if re == nil { // to prevent SIGSEGV
	return p.WithError(errors.New("nil regular expression"))
}
```
Then, I realized that `p` will not be automatically closed, since the subsequent filters and sinks will catch the error and return immediately. To fix this problem and prevent contributors from making the same mistake in the future, I think the best approach is to just close the pipe reader when a non-nil error is set.

**Add ExecForEach, Reject(), and RejectRegexp to doMethodsOnPipe tests**
Just some jobs that previous contributors forgot.

**Improve coverage by adding equal counts in the test case of Freq**
To test that lines are sorted in alphabetical order when there is a tie.

**Use io.Copy() in Stdout() to improve efficiency**
It seems unnecessary to write the pipe's reader into a string and then print it.

By the way, after all the changes, the total line coverage has risen from 92.7% to 93.8%.