### PR TITLE
使Exec函数返回的错误信息更可读

### DIFF
--- a/filters.go
+++ b/filters.go
@@ -6,6 +6,7 @@ import (
 	"container/ring"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -133,7 +134,7 @@ func (p *Pipe) Exec(cmdLine string) *Pipe {
 	cmd.Stdin = p.Reader
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		q.SetError(err)
+		q.SetError(errors.New(err.Error() + ":" + string(output)))
 	}
 	return q.WithReader(bytes.NewReader(output))
 }

--- a/filters.go
+++ b/filters.go
@@ -134,7 +134,7 @@ func (p *Pipe) Exec(cmdLine string) *Pipe {
 	cmd.Stdin = p.Reader
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		q.SetError(errors.New(err.Error() + ":" + string(output)))
+		q.SetError(errors.New(err.Error() + ": " + string(output)))
 	}
 	return q.WithReader(bytes.NewReader(output))
 }


### PR DESCRIPTION
通常，即使命令执行失败，命令的输出也会揭示失败的原因，将这种错误信息返回给开发者，以帮助他们更好的排查错误原因。