### PR TITLE
Implementation of parallel execution for ExecForEach() and EachLine()

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,9 +577,9 @@ Examples:
 | `./src/filters`    | `./src`          |
 | `C:/Program Files` | `C:`             |
 
-## EachLine
+## EachLine and EachLineConc
 
-`EachLine()` lets you create custom filters. You provide a function, and it will be called once for each line of input. If you want to produce output, your function can write to a supplied `strings.Builder`. The return value from EachLine is a pipe containing your output.
+`EachLine()` and `EachLineConc()` let you create custom filters. You provide a function, and it will be called once for each line of input. If you want to produce output, your function can write to a supplied `strings.Builder`. The return value is a pipe containing your output. `EachLine()` runs the function line by line, whereas `EachLineConc()` runs on the lines concurrently. Both methods output in the order corresponding to their input.
 
 ```go
 p := script.File("test.txt")
@@ -604,13 +604,17 @@ fmt.Println(output)
 // Output: hello world
 ```
 
-## ExecForEach
+## ExecForEach and ExecForEachConc
 
-ExecForEach runs the supplied command once for each line of input, and returns a pipe containing the output, like Unix `xargs`.
+ExecForEach and ExecForEachConc run the supplied command once for each line of input, and returns a pipe containing the output, like Unix `xargs`.
 
 The command string is interpreted as a Go template, so `{{.}}` will be replaced with the input value, for example.
 
-The first command that results in an error will set the pipe's error status accordingly, and no subsequent commands will be run.
+ExecForEach runs commands line by line. The first command that results in an error will set the pipe's error status accordingly, and no subsequent commands will be run.
+
+By contrast, ExecForEachConc runs commands concurrently, like Unix '&', which improves efficiency when the command is time-consuming. 
+
+Both methods output in the order corresponding to their input.
 
 ```go
 // Execute all PHP files in current directory and print output

--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ John is also the author of [For the Love of Go](https://bitfieldconsulting.com/b
 	- [Concat](#concat)
 	- [Dirname](#dirname)
 	- [EachLine](#eachline)
+	- [EachLineConc](#eachlineconc)
 	- [Exec](#exec-1)
 	- [ExecForEach](#execforeach)
+	- [ExecForEachConc](#execforeachconc)
 	- [First](#first)
 	- [Freq](#freq)
 	- [Join](#join)
@@ -311,6 +313,7 @@ If you're already familiar with shell scripting and the Unix toolset, here is a 
 | `uniq -c`          | [`Freq()`](#freq)                                             |
 | `wc -l`            | [`CountLines()`](#countlines)                                 |
 | `xargs`            | [`ExecForEach()`](#execforeach)                               |
+| `xargs -P`         | [`ExecForEachConc()`](#execforeachconc)                       |
 
 # Sources, filters, and sinks
 

--- a/filters.go
+++ b/filters.go
@@ -220,15 +220,20 @@ func (p *Pipe) ExecForEachConc(cmdTpl string) *Pipe {
 	if err != nil {
 		return p.WithError(err)
 	}
+	mu := sync.Mutex{}
 	return p.EachLineConc(func(line string, out *strings.Builder) {
 		cmdLine := strings.Builder{}
 		err := tpl.Execute(&cmdLine, line)
 		if err != nil {
+			mu.Lock()
+			defer mu.Unlock()
 			p.SetError(err)
 			return
 		}
 		cmdOutput, err := Exec(cmdLine.String()).String()
 		if err != nil {
+			mu.Lock()
+			defer mu.Unlock()
 			p.SetError(err)
 			return
 		}

--- a/pipes_test.go
+++ b/pipes_test.go
@@ -111,10 +111,16 @@ func doMethodsOnPipe(t *testing.T, p *Pipe, kind string) {
 	p.Dirname()
 	action = "EachLine()"
 	p.EachLine(func(string, *strings.Builder) {})
+	action = "EachLineConc()"
+	p.EachLineConc(func(string, *strings.Builder) {})
 	action = "Error()"
 	p.Error()
 	action = "Exec()"
 	p.Exec("bogus")
+	action = "ExecForEach()"
+	p.ExecForEach("bogus")
+	action = "ExecForEachConc()"
+	p.ExecForEachConc("bogus")
 	action = "ExitStatus()"
 	p.ExitStatus()
 	action = "First()"


### PR DESCRIPTION
The pull request relates to issue #87 and implements the parallel execution for ExecForEach() and EachLine().

The code has been fully tested to ensure that the order of input is preserved (by executing a large test case 1000 times) and there is no race condition (by running `go test -race`).