### PR TITLE
Fix #81

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.17
     steps:
       - checkout
       - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -861,7 +861,7 @@ fmt.Println(err)
 
 ## WriteFile
 
-`WriteFile()` writes the contents of the pipe to a named file. It returns the number of bytes written, or an error:
+`WriteFile()` writes the contents of the pipe to a named file, truncating it if it exists. It returns the number of bytes written, or an error:
 
 ```go
 var wrote int

--- a/sinks.go
+++ b/sinks.go
@@ -105,11 +105,12 @@ func (p *Pipe) String() (string, error) {
 }
 
 // WriteFile writes the contents of the Pipe to the specified file, and closes
-// the pipe after reading. It returns the number of bytes successfully written,
-// or an error. If there is an error reading or writing, the pipe's error status
-// is also set.
+// the pipe after reading. If the file already exists, it is truncated and the
+// new data will replace the old. It returns the number of bytes successfully
+// written, or an error. If there is an error reading or writing, the pipe's
+// error status is also set.
 func (p *Pipe) WriteFile(fileName string) (int64, error) {
-	return p.writeOrAppendFile(fileName, os.O_RDWR|os.O_CREATE)
+	return p.writeOrAppendFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC)
 }
 
 func (p *Pipe) writeOrAppendFile(fileName string, mode int) (int64, error) {


### PR DESCRIPTION
WriteFile is supposed to truncate and overwrite an existing file. In fact, it was overwriting the beginning of the file with the new data, but leaving the remaining old data intact. Adding the O_TRUNC flag to os.OpenFile fixes this.