### PR TITLE
Added `AppendFileUnique()` function

### DIFF
--- a/script.go
+++ b/script.go
@@ -897,3 +897,4 @@ func fileExists(filepath string) bool {
 	}
 	return false
 }
+


### PR DESCRIPTION
Suppose we have two files as following:
```
$ cat a.file
a
a
1
1
b
```
```
$ cat b.file
a
2 
```
Running `script.Exec("cat a.file").AppendFileUnique("b.file")` will change the b.file into:
```
$ cat b.file
a
2
1
b
```


#### AppenFileUnique() 
* Takes the data from pipe, then uniquely appends it to the specified file. 
* It avoids appending the line if its already in the specified file. 
* Creates the specified file if it doesn't exist. 
* Returns the unique list of slice containing appended values


##### TLDR, As a person who has to deal with text files almost everyday, this is something I use very often with a custom script. Thought it'd be great to have it added to this package.
