### PR TITLE
#110 - Fix Slice bug producing a \n when provided with an empty slice

### DIFF
--- a/script.go
+++ b/script.go
@@ -291,6 +291,9 @@ func ListFiles(path string) *Pipe {
 // Slice creates a pipe containing each element of the supplied slice of
 // strings, one per line.
 func Slice(s []string) *Pipe {
+	if len(s) <= 0 {
+		return Echo(strings.Join(s, ""))
+	}
 	return Echo(strings.Join(s, "\n") + "\n")
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -1132,7 +1132,6 @@ func TestSliceProducesNoElementsWhenProvidedWithAnEmptyList(t *testing.T) {
 	// TODO: Properly add tests
 	want := ""
 	got, err := script.ListFiles("../example").String()
-	//got, err := script.Slice([]string{}).String()
 
 	if err != nil {
 		t.Fatal(err)

--- a/script_test.go
+++ b/script_test.go
@@ -1075,12 +1075,6 @@ func TestListFiles_OutputsSingleFileGivenFilePath(t *testing.T) {
 	}
 }
 
-func TestListFiles_DoesNotOutputNewLineIfProvidedSliceIsEmpty(t *testing.T) {
-	// TODO: Add unit tests
-
-	t.Parallel()
-}
-
 func TestListFiles_OutputsAllFilesMatchingSpecifiedGlobExpression(t *testing.T) {
 	t.Parallel()
 	want := filepath.Clean("testdata/multiple_files/1.txt\ntestdata/multiple_files/2.txt\n")

--- a/script_test.go
+++ b/script_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1124,7 +1125,7 @@ func TestSliceProducesNoElementsWhenProvidedWithAnEmptyList(t *testing.T) {
 	t.Parallel()
 
 	want := ""
-	got, err := script.ListFiles("../example").String()
+	got, err := script.Slice([]string{}).String()
 
 	if err != nil {
 		t.Fatal(err)

--- a/script_test.go
+++ b/script_test.go
@@ -1126,6 +1126,23 @@ func TestSliceProducesElementsOfSpecifiedSliceOnePerLine(t *testing.T) {
 	}
 }
 
+func TestSliceProducesNoElementsWhenProvidedWithAnEmptyList(t *testing.T) {
+	t.Parallel()
+
+	// TODO: Properly add tests
+	want := ""
+	got, err := script.ListFiles("../example").String()
+	//got, err := script.Slice([]string{}).String()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cmp.Equal(want, got) {
+		t.Error(cmp.Diff(want, got))
+	}
+}
+
 func TestStdinReadsFromProgramStandardInput(t *testing.T) {
 	t.Parallel()
 	// dummy test to prove coverage

--- a/script_test.go
+++ b/script_test.go
@@ -1075,6 +1075,10 @@ func TestListFiles_OutputsSingleFileGivenFilePath(t *testing.T) {
 	}
 }
 
+func TestListFiles_DoesNotOutputNewLineIfProvidedSliceIsEmpty(t *testing.T) {
+	t.Parallel()
+}
+
 func TestListFiles_OutputsAllFilesMatchingSpecifiedGlobExpression(t *testing.T) {
 	t.Parallel()
 	want := filepath.Clean("testdata/multiple_files/1.txt\ntestdata/multiple_files/2.txt\n")

--- a/script_test.go
+++ b/script_test.go
@@ -1123,7 +1123,6 @@ func TestSliceProducesElementsOfSpecifiedSliceOnePerLine(t *testing.T) {
 func TestSliceProducesNoElementsWhenProvidedWithAnEmptyList(t *testing.T) {
 	t.Parallel()
 
-	// TODO: Properly add tests
 	want := ""
 	got, err := script.ListFiles("../example").String()
 

--- a/script_test.go
+++ b/script_test.go
@@ -1076,6 +1076,8 @@ func TestListFiles_OutputsSingleFileGivenFilePath(t *testing.T) {
 }
 
 func TestListFiles_DoesNotOutputNewLineIfProvidedSliceIsEmpty(t *testing.T) {
+	// TODO: Add unit tests
+
 	t.Parallel()
 }
 


### PR DESCRIPTION
> see #110 for discussion

Resolved a minor bug where Slice was returning an newline when an empty string slice was passed into it.

The expected behaviour: 

```Go
// Slice creates a pipe containing each element of the supplied slice of
// strings, one per line

result, err := script.ListFiles("/empty/path/")

// result returns ""
```

The Actual Behaviour:

```Go
result, err := script.ListFiles("/empty/path/")

// result returns "\n"
```

## Use Case for PR
This MR will add logic that will tell Slice to check the length of the incoming string slice (`len([]string{ ... })`) and if it's less than or equal to 0, or if it's empty, it should tell Slice to return a pipe containing an empty string rather than a `"\n"`

Slice is used often in the script codebase particularly in `ListFiles()` where the bug was first discovered. This implementation should resolve it.