### PR TITLE
Fix exit code issue

### DIFF
--- a/script.go
+++ b/script.go
@@ -103,6 +103,7 @@ func (p *Pipe) Error() error {
 }
 
 var exitStatusPattern = regexp.MustCompile(`exit status (\d+)$`)
+var nonExistentCmdPattern = regexp.MustCompile(`executable file not found in`)
 
 // ExitStatus returns the integer exit status of a previous command, if the
 // pipe's error status is set, and if the error matches the pattern "exit status
@@ -110,6 +111,9 @@ var exitStatusPattern = regexp.MustCompile(`exit status (\d+)$`)
 func (p *Pipe) ExitStatus() int {
 	if p.Error() == nil {
 		return 0
+	}
+	if nonExistentCmdPattern.MatchString(p.Error().Error()) {
+		return 127
 	}
 	match := exitStatusPattern.FindStringSubmatch(p.Error().Error())
 	if len(match) < 2 {
@@ -140,9 +144,6 @@ func (p *Pipe) SetError(err error) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if err != nil {
-		p.Close()
-	}
 	p.err = err
 }
 


### PR DESCRIPTION
Add a non-existent command regex pattern and remove the close pipe from the setError function.

Closes #117 