### PR TITLE
Fixing Go routine leaks because of not closing http requests.

### DIFF
--- a/script.go
+++ b/script.go
@@ -590,6 +590,7 @@ func (p *Pipe) Get(URL string) *Pipe {
 	if err != nil {
 		return p.WithError(err)
 	}
+	req.Close = true
 	return p.Do(req)
 }
 
@@ -700,6 +701,7 @@ func (p *Pipe) Post(URL string) *Pipe {
 	if err != nil {
 		return p.WithError(err)
 	}
+	req.Close = true
 	return p.Do(req)
 }
 


### PR DESCRIPTION
We are using code that lets us detect dead locks which also checks for go routines that are still running when the program ends. I saw this getting triggered and found the cause in not telling the requests to close after use.