### PR TITLE
Make Bytes error return behavior consistent with String

### DIFF
--- a/script.go
+++ b/script.go
@@ -221,7 +221,7 @@ func (p *Pipe) Bytes() ([]byte, error) {
 	if err != nil {
 		p.SetError(err)
 	}
-	return data, nil
+	return data, p.Error()
 }
 
 // Close closes the pipe's associated reader. This is a no-op if the reader is


### PR DESCRIPTION
The `Bytes` method does not return error when the pipe has a non-zero exit status while the corresponding `String` method does.

This PR makes `Bytes` also return an error, making it consistent with `String`. 

Closes #170 