### PR TITLE
Apply operator: adding pre-composed operators together

### DIFF
--- a/script.go
+++ b/script.go
@@ -193,7 +193,7 @@ func Stdin() *Pipe {
 }
 
 // Apply allows to 
-func (p *Pipe) Apply(fn func(p *Pipe) *Pipe) *.Pipe {
+func (p *Pipe) Apply(fn func(p *Pipe) *Pipe) *Pipe {
 	return fn(p)
 }
 

--- a/script.go
+++ b/script.go
@@ -192,6 +192,12 @@ func Stdin() *Pipe {
 	return NewPipe().WithReader(os.Stdin)
 }
 
+// Apply allows to 
+func (p *Pipe) Apply(fn func(p *Pipe) *Pipe) *.Pipe {
+	return fn(p)
+}
+
+
 // AppendFile appends the contents of the pipe to the file path, creating it if
 // necessary, and returns the number of bytes successfully written, or an
 // error.


### PR DESCRIPTION
Hey @bitfield ,

Thanks for this awesome toolbelt :)

I've felt one generic tool missing in here, basically a Transformer as explained here: https://blog.danlew.net/2015/03/02/dont-break-the-chain/

This allows code like the following, which allows for creation of higher level operators:

```go
	_, err := script.NewPipe().
		Apply(ExecAndStdout(`rm -Rf nsc/docs`)).
		Apply(ExecAndStdout(`mkdir nsc/docs`)).
		Stdout()


func ExecAndStdout(format string, args ...any) func(p *script.Pipe) *script.Pipe {
	return func(p *script.Pipe) *script.Pipe {
		p = p.Exec(fmt.Sprintf(format, args...)).Filter(StdoutAndContinue)
		p.Wait()
		// after p.Wait, the reader was fully consumed and auto-closing.
		// to prevent the error "io: read/write on closed pipe",
		// we need to re-initialize the reader.
		p.Reader = script.NewReadAutoCloser(strings.NewReader(""))
		return p
	}
}

```

If you generally give a +1 to the direction, I'll add detailed doc comments with examples like the above.

Thanks and all the best,
Sebastian