### PR TITLE
optimize Pipe.Wait

### DIFF
--- a/script.go
+++ b/script.go
@@ -849,7 +849,7 @@ func (p *Pipe) Tee(writers ...io.Writer) *Pipe {
 // useful for waiting until concurrent filters have completed (see
 // [Pipe.Filter]).
 func (p *Pipe) Wait() {
-	_, err := io.ReadAll(p)
+	_, err := io.Copy(io.Discard, p)
 	if err != nil {
 		p.SetError(err)
 	}


### PR DESCRIPTION
use io.Copy with io.Discard instead of io.ReadAll to avoid allocating a buffer just to throw it away

see io.Copy and io.Discard implementation:
https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/io/io.go;l=408;drc=1ff89009f198ad5bae3549dd3b992882bd97e5f8
https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/io/io.go;drc=1ff89009f198ad5bae3549dd3b992882bd97e5f8;l=635

vs io.ReadAll:
https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/io/io.go;l=701;drc=1ff89009f198ad5bae3549dd3b992882bd97e5f8