### PR TITLE
Update First(n int) to read no more data than necessary

### DIFF
--- a/script.go
+++ b/script.go
@@ -967,10 +967,3 @@ func newScanner(r io.Reader) *bufio.Scanner {
 	scanner.Buffer(make([]byte, 4096), math.MaxInt)
 	return scanner
 }
-
-// Prompt creates a pipe that reads user input from stdin after displaying the
-// specified prompt.
-func Prompt(prompt string) *Pipe {
-	fmt.Print(prompt)
-	return Stdin().First(1)
-}

--- a/script.go
+++ b/script.go
@@ -514,7 +514,8 @@ func (p *Pipe) FilterScan(filter func(string, io.Writer)) *Pipe {
 
 // First produces only the first n lines of the pipe's contents, or all the
 // lines if there are less than n. If n is zero or negative, there is no output
-// at all.
+// at all. When n lines have been produced, First stops reading its input and
+// sends EOF to its output.
 func (p *Pipe) First(n int) *Pipe {
 	if p.Error() != nil {
 		return p
@@ -524,15 +525,10 @@ func (p *Pipe) First(n int) *Pipe {
 	}
 	return p.Filter(func(r io.Reader, w io.Writer) error {
 		scanner := newScanner(r)
-		i := 0
-		for scanner.Scan() {
+		for i := 0; i < n && scanner.Scan(); i++ {
 			_, err := fmt.Fprintln(w, scanner.Text())
 			if err != nil {
 				return err
-			}
-			i++
-			if i >= n {
-				break
 			}
 		}
 		return scanner.Err()

--- a/script_test.go
+++ b/script_test.go
@@ -573,6 +573,24 @@ func TestFirstHasNoEffectGivenLessThanNInputLines(t *testing.T) {
 	}
 }
 
+func TestFirstDoesNotConsumeUnnecessaryData(t *testing.T) {
+	t.Parallel()
+	// First uses a 4096-byte buffer, so will always read at least
+	// that much, but no more (once N lines have been read).
+	r := strings.NewReader(strings.Repeat("line\n", 1000))
+	got, err := script.NewPipe().WithReader(r).First(1).String()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "line\n"
+	if want != got {
+		t.Errorf("want output %q, got %q", want, got)
+	}
+	if r.Len() == 0 {
+		t.Errorf("no data left in reader")
+	}
+}
+
 func TestFreqHandlesLongLines(t *testing.T) {
 	t.Parallel()
 	got, err := script.Echo(longLine).Freq().Slice()


### PR DESCRIPTION
This slightly modifies `First` and introduces `Prompt` that can be used for user input:

```go
fmt.Print("User input: ")
input, _ := script.Stdin().First(1).String()
fmt.Printf("Input was %s\n", input)
```

or

```go
input, _ := script.Prompt("User input: ").String()
fmt.Printf("Input was %s\n", input)
```

Fixes #51, #132