### PR TITLE
Allow for script.Exec() to be used like exec.Command()

### DIFF
--- a/script.go
+++ b/script.go
@@ -59,8 +59,8 @@ func Echo(s string) *Pipe {
 //
 // Use [Pipe.Exec] to send the contents of an existing pipe to the command's
 // standard input.
-func Exec(cmdLine string) *Pipe {
-	return NewPipe().Exec(cmdLine)
+func Exec(cmdLine string, args ...string) *Pipe {
+	return NewPipe().Exec(cmdLine, args...)
 }
 
 // File creates a pipe that reads from the file path.
@@ -375,9 +375,10 @@ func (p *Pipe) Error() error {
 // If the command writes to its standard error stream, this will also go to the
 // pipe, along with its standard output. However, the standard error text can
 // instead be redirected to a supplied writer, using [Pipe.WithStderr].
-func (p *Pipe) Exec(cmdLine string) *Pipe {
+func (p *Pipe) Exec(cmdLine string, args ...string) *Pipe {
 	return p.Filter(func(r io.Reader, w io.Writer) error {
-		args, err := shell.Fields(cmdLine, nil)
+		parsedArgs, err := shell.Fields(cmdLine, nil)
+		args = append(parsedArgs, args...)
 		if err != nil {
 			return err
 		}

--- a/script_test.go
+++ b/script_test.go
@@ -1201,6 +1201,21 @@ func TestExecRunsGoHelpAndGetsUsageMessage(t *testing.T) {
 	}
 }
 
+func TestExecRunsGoHelpVariantAndGetsUsageMessage(t *testing.T) {
+	t.Parallel()
+	p := script.Exec("go", "help")
+	if p.Error() != nil {
+		t.Fatal(p.Error())
+	}
+	output, err := p.String()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "Usage") {
+		t.Fatalf("want output containing the word 'Usage', got %q", output)
+	}
+}
+
 func TestFileOutputsContentsOfSpecifiedFile(t *testing.T) {
 	t.Parallel()
 	want := "This is the first line in the file.\nHello, world.\nThis is another line in the file.\n"


### PR DESCRIPTION
A small update to allow for `exec.Command(name string, arg ...string)` style arguments.

```go
script.Exec("go", "help")
```