### PR TITLE
feat: exec with context

### DIFF
--- a/script.go
+++ b/script.go
@@ -31,7 +31,7 @@ type Pipe struct {
 	Reader         ReadAutoCloser
 	stdout, stderr io.Writer
 	httpClient     *http.Client
-
+	ctx            context.Context
 	// because pipe stages are concurrent, protect 'err'
 	mu  *sync.Mutex
 	err error
@@ -62,16 +62,6 @@ func Echo(s string) *Pipe {
 // standard input.
 func Exec(cmdLine string) *Pipe {
 	return NewPipe().Exec(cmdLine)
-}
-
-// Exec creates a pipe that runs cmdLine as an external command and produces
-// its combined output (interleaving standard output and standard error). See
-// [Pipe.Exec] for error handling details.
-//
-// Use [Pipe.Exec] to send the contents of an existing pipe to the command's
-// standard input.
-func ExecContext(ctx context.Context, cmdLine string) *Pipe {
-	return NewPipe().ExecContext(ctx, cmdLine)
 }
 
 // File creates a pipe that reads from the file path.
@@ -175,6 +165,7 @@ func NewPipe() *Pipe {
 	return &Pipe{
 		Reader:     ReadAutoCloser{},
 		mu:         new(sync.Mutex),
+		ctx:        context.Background(),
 		stdout:     os.Stdout,
 		httpClient: http.DefaultClient,
 	}
@@ -392,48 +383,7 @@ func (p *Pipe) Exec(cmdLine string) *Pipe {
 		if err != nil {
 			return err
 		}
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Stdin = r
-		cmd.Stdout = w
-		cmd.Stderr = w
-		if p.stderr != nil {
-			cmd.Stderr = p.stderr
-		}
-		err = cmd.Start()
-		if err != nil {
-			fmt.Fprintln(cmd.Stderr, err)
-			return err
-		}
-		return cmd.Wait()
-	})
-}
-
-// Exec runs cmdLine as an external command, sending it the contents of the
-// pipe as input, and produces the command's standard output (see below for
-// error output). The effect of this is to filter the contents of the pipe
-// through the external command. It also allows passing context.Context making
-// it cancellable
-//
-// # Error handling
-//
-// If the command had a non-zero exit status, the pipe's error status will also
-// be set to the string “exit status X”, where X is the integer exit status.
-// Even in the event of a non-zero exit status, the command's output will still
-// be available in the pipe. This is often helpful for debugging. However,
-// because [Pipe.String] is a no-op if the pipe's error status is set, if you
-// want output you will need to reset the error status before calling
-// [Pipe.String].
-//
-// If the command writes to its standard error stream, this will also go to the
-// pipe, along with its standard output. However, the standard error text can
-// instead be redirected to a supplied writer, using [Pipe.WithStderr].
-func (p *Pipe) ExecContext(ctx context.Context, cmdLine string) *Pipe {
-	return p.Filter(func(r io.Reader, w io.Writer) error {
-		args, err := shell.Fields(cmdLine, nil)
-		if err != nil {
-			return err
-		}
-		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+		cmd := exec.CommandContext(p.ctx, args[0], args[1:]...)
 		cmd.Stdin = r
 		cmd.Stdout = w
 		cmd.Stderr = w
@@ -474,7 +424,7 @@ func (p *Pipe) ExecForEach(cmdLine string) *Pipe {
 			if err != nil {
 				return err
 			}
-			cmd := exec.Command(args[0], args[1:]...)
+			cmd := exec.CommandContext(p.ctx, args[0], args[1:]...)
 			cmd.Stdout = w
 			cmd.Stderr = w
 			if p.stderr != nil {
@@ -494,54 +444,6 @@ func (p *Pipe) ExecForEach(cmdLine string) *Pipe {
 		return scanner.Err()
 	})
 }
-
-// ExecContextForEach renders cmdLine as a Go template for each line of input, running
-// the resulting command, and produces the combined output of all these
-// commands in sequence. See [Pipe.ExecContext] for error handling details. 
-// It also allows to pass context.Context allowing to cancel the execution
-//
-// This is mostly useful for substituting data into commands using Go template
-// syntax. For example:
-//
-//	ListFiles("*").ExecForEach("touch {{.}}").Wait()
-func (p *Pipe) ExecContextForEach(ctx context.Context, cmdLine string) *Pipe {
-	tpl, err := template.New("").Parse(cmdLine)
-	if err != nil {
-		return p.WithError(err)
-	}
-	return p.Filter(func(r io.Reader, w io.Writer) error {
-		scanner := newScanner(r)
-		for scanner.Scan() {
-			cmdLine := new(strings.Builder)
-			err := tpl.Execute(cmdLine, scanner.Text())
-			if err != nil {
-				return err
-			}
-			args, err := shell.Fields(cmdLine.String(), nil)
-			if err != nil {
-				return err
-			}
-			cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-			cmd.Stdout = w
-			cmd.Stderr = w
-			if p.stderr != nil {
-				cmd.Stderr = p.stderr
-			}
-			err = cmd.Start()
-			if err != nil {
-				fmt.Fprintln(cmd.Stderr, err)
-				continue
-			}
-			err = cmd.Wait()
-			if err != nil {
-				fmt.Fprintln(cmd.Stderr, err)
-				continue
-			}
-		}
-		return scanner.Err()
-	})
-}
-
 
 var exitStatusPattern = regexp.MustCompile(`exit status (\d+)$`)
 
@@ -995,6 +897,13 @@ func (p *Pipe) WithStderr(w io.Writer) *Pipe {
 // default [os.Stdout].
 func (p *Pipe) WithStdout(w io.Writer) *Pipe {
 	p.stdout = w
+	return p
+}
+
+// WithContext sets context.Context for the pipe. Adds support for graceful pipe
+// shutdown. Currently works with [Pipe.Exec] and [Pipe.ExecForEach]
+func (p *Pipe) WithContext(ctx context.Context) *Pipe {
+	p.ctx = ctx
 	return p
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -1221,7 +1221,7 @@ func TestExecRunsGoHelpAndGetsUsageMessage(t *testing.T) {
 	}
 }
 
-func TestExecContextCencel(t *testing.T) {
+func TestWithContextTimeout(t *testing.T) {
 	t.Parallel()
 	// We can't make many cross-platform assumptions about what external
 	// commands will be available, but it seems logical that 'go' would be

--- a/script_test.go
+++ b/script_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 	"testing/iotest"
+	"time"
 
 	"github.com/bitfield/script"
 	"github.com/google/go-cmp/cmp"
@@ -1225,13 +1226,13 @@ func TestExecContextCencel(t *testing.T) {
 	// We can't make many cross-platform assumptions about what external
 	// commands will be available, but it seems logical that 'go' would be
 	// (though it may not be in the user's path)
-	ctx, cancel := context.WithTimeout(context.Background(), 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
-	p := script.ExecContext(ctx, "sleep 100")
+	p := script.NewPipe().WithContext(ctx).Exec("sleep 1")
 	p.Wait()
-  err := p.Error()
-	if err == nil {
-		t.Fatal("when command is canceled there should be an error")
+	err := p.Error()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("context should timeout")
 	}
 	t.Log(p.ExitStatus())
 }

--- a/script_test.go
+++ b/script_test.go
@@ -3,6 +3,7 @@ package script_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -1217,6 +1218,22 @@ func TestExecRunsGoHelpAndGetsUsageMessage(t *testing.T) {
 	if !strings.Contains(output, "Usage") {
 		t.Fatalf("want output containing the word 'Usage', got %q", output)
 	}
+}
+
+func TestExecContextCencel(t *testing.T) {
+	t.Parallel()
+	// We can't make many cross-platform assumptions about what external
+	// commands will be available, but it seems logical that 'go' would be
+	// (though it may not be in the user's path)
+	ctx, cancel := context.WithTimeout(context.Background(), 1)
+	defer cancel()
+	p := script.ExecContext(ctx, "sleep 100")
+	p.Wait()
+  err := p.Error()
+	if err == nil {
+		t.Fatal("when command is canceled there should be an error")
+	}
+	t.Log(p.ExitStatus())
 }
 
 func TestFileOutputsContentsOfSpecifiedFile(t *testing.T) {

--- a/script_test.go
+++ b/script_test.go
@@ -1223,9 +1223,6 @@ func TestExecRunsGoHelpAndGetsUsageMessage(t *testing.T) {
 
 func TestWithContextTimeout(t *testing.T) {
 	t.Parallel()
-	// We can't make many cross-platform assumptions about what external
-	// commands will be available, but it seems logical that 'go' would be
-	// (though it may not be in the user's path)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
 	p := script.NewPipe().WithContext(ctx).Exec("sleep 1")

--- a/testdata/test_cli.go
+++ b/testdata/test_cli.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const commandSleep = "sleep"
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("No command provided")
+		usage()
+		os.Exit(1)
+	}
+
+	handleSignals()
+
+	switch strings.ToLower(os.Args[1]) {
+	case commandSleep:
+		if len(os.Args) != 3 {
+			fmt.Printf("Usage: %s %s <seconds>\n", os.Args[0], commandSleep)
+			usage()
+			os.Exit(1)
+		}
+		err := sleep(os.Args[2])
+		if err != nil {
+			fmt.Printf("Error sleeping: %s\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Printf("Unknown command: %s\n", os.Args[1])
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Printf("Usage of %s:\n", os.Args[0])
+	fmt.Printf("     sleep <seconds>\n")
+}
+
+func sleep(seconds string) error {
+	s, err := strconv.Atoi(seconds)
+	if err != nil {
+		return fmt.Errorf("sleep expects an integer, got %s", seconds)
+	}
+	<-time.After(time.Duration(s) * time.Second)
+	return nil
+}
+
+func handleSignals() {
+	sigs := make(chan os.Signal, 1)
+
+	signal.Notify(sigs, syscall.SIGINT)
+
+	go func() {
+		<-sigs
+		fmt.Println("\nReceived Ctrl+C, exiting...")
+		os.Exit(0)
+	}()
+}


### PR DESCRIPTION
Would ExecContext make sense ? 

This will allow us to cancel long-running commands with the standard go pattern