### PR TITLE
feat: add `WithEnv` method for setting a task's environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,18 +269,31 @@ These are functions that create a pipe with a given contents:
 
 | Source | Contents |
 | -------- | ------------- |
-| [`Args`](https://pkg.go.dev/github.com/bitfield/script#Args) | command-line arguments
-| [`Do`](https://pkg.go.dev/github.com/bitfield/script#Do) | HTTP response
-| [`Echo`](https://pkg.go.dev/github.com/bitfield/script#Echo) | a string
-| [`Exec`](https://pkg.go.dev/github.com/bitfield/script#Exec) | command output
-| [`File`](https://pkg.go.dev/github.com/bitfield/script#File) | file contents
-| [`FindFiles`](https://pkg.go.dev/github.com/bitfield/script#FindFiles) | recursive file listing
-| [`Get`](https://pkg.go.dev/github.com/bitfield/script#Get) | HTTP response
-| [`IfExists`](https://pkg.go.dev/github.com/bitfield/script#IfExists) | do something only if some file exists
-| [`ListFiles`](https://pkg.go.dev/github.com/bitfield/script#ListFiles) | file listing (including wildcards)
-| [`Post`](https://pkg.go.dev/github.com/bitfield/script#Post) | HTTP response
-| [`Slice`](https://pkg.go.dev/github.com/bitfield/script#Slice) | slice elements, one per line
-| [`Stdin`](https://pkg.go.dev/github.com/bitfield/script#Stdin) | standard input
+| [`Args`](https://pkg.go.dev/github.com/bitfield/script#Args) | command-line arguments |
+| [`Do`](https://pkg.go.dev/github.com/bitfield/script#Do) | HTTP response |
+| [`Echo`](https://pkg.go.dev/github.com/bitfield/script#Echo) | a string |
+| [`Exec`](https://pkg.go.dev/github.com/bitfield/script#Exec) | command output |
+| [`File`](https://pkg.go.dev/github.com/bitfield/script#File) | file contents |
+| [`FindFiles`](https://pkg.go.dev/github.com/bitfield/script#FindFiles) | recursive file listing |
+| [`Get`](https://pkg.go.dev/github.com/bitfield/script#Get) | HTTP response |
+| [`IfExists`](https://pkg.go.dev/github.com/bitfield/script#IfExists) | do something only if some file exists |
+| [`ListFiles`](https://pkg.go.dev/github.com/bitfield/script#ListFiles) | file listing (including wildcards) |
+| [`Post`](https://pkg.go.dev/github.com/bitfield/script#Post) | HTTP response |
+| [`Slice`](https://pkg.go.dev/github.com/bitfield/script#Slice) | slice elements, one per line |
+| [`Stdin`](https://pkg.go.dev/github.com/bitfield/script#Stdin) | standard input |
+
+## Modifiers
+
+These are methods on a pipe that change its configuration:
+
+| Source | Modifies |
+| -------- | ------------- |
+| [`WithEnv`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithEnv) | environment for commands |
+| [`WithError`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithError) | pipe error status |
+| [`WithHTTPClient`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithHTTPClient) | client for HTTP requests |
+| [`WithReader`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithReader) | pipe source |
+| [`WithStderr`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStderr) | standard error output stream for command |
+| [`WithStdout`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStdout) | standard output stream for pipe |
 
 ## Filters
 
@@ -340,7 +353,8 @@ Sinks are methods that return some data from a pipe, ending the pipeline and ext
 
 | Version | New |
 | ----------- | ------- |
-| _next_  | [`DecodeBase64`](https://pkg.go.dev/github.com/bitfield/script#Pipe.DecodeBase64) / [`EncodeBase64`](https://pkg.go.dev/github.com/bitfield/script#Pipe.EncodeBase64) |
+| _next_  | [`WithEnv`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithEnv) |
+|         | [`DecodeBase64`](https://pkg.go.dev/github.com/bitfield/script#Pipe.DecodeBase64) / [`EncodeBase64`](https://pkg.go.dev/github.com/bitfield/script#Pipe.EncodeBase64) |
 | v0.22.0 | [`Tee`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Tee), [`WithStderr`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStderr) |
 | v0.21.0 | HTTP support: [`Do`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Do), [`Get`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Get), [`Post`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Post) |
 | v0.20.0 | [`JQ`](https://pkg.go.dev/github.com/bitfield/script#Pipe.JQ) |

--- a/script.go
+++ b/script.go
@@ -35,7 +35,7 @@ type Pipe struct {
 	mu  *sync.Mutex
 	err error
 
-	// env contains the environment to run the exec command with.
+	// env contains the environment to run any exec commands with.
 	// Each entry in the array should be of the form key=value.
 	// If env is not nil, it will replace the default environment variables
 	// when executing commands.

--- a/script.go
+++ b/script.go
@@ -32,10 +32,6 @@ type Pipe struct {
 	stdout     io.Writer
 	httpClient *http.Client
 
-	// because pipe stages are concurrent, protect 'err'
-	mu  *sync.Mutex
-	err error
-
 	// env contains the environment to run any exec commands with.
 	// Each entry in the array should be of the form key=value.
 	// If env is not nil, it will replace the default environment variables

--- a/script.go
+++ b/script.go
@@ -39,13 +39,7 @@ type Pipe struct {
 	mu     *sync.Mutex
 	err    error
 	stderr io.Writer
-	// env contains the environment to run any exec commands with.
-	// Each entry in the array should be of the form key=value.
-	// If env is not nil, it will replace the default environment variables
-	// when executing commands.
-	// If env is an empty array, any exec commands will be run with an
-	// empty environment.
-	env []string
+	env    []string
 }
 
 // Args creates a pipe containing the program's command-line arguments from
@@ -929,8 +923,9 @@ func (p *Pipe) Wait() error {
 
 // WithEnv sets the environment for subsequent [Pipe.Exec] and [Pipe.ExecForEach] commands
 // to the string slice env. This will override the default process environment variables
-// when executing commands run via [Pipe.Exec] or [Pipe.ExecForEach]. This will not affect
-// the current process's environment.
+// when executing commands run via [Pipe.Exec] or [Pipe.ExecForEach].
+// Each entry in the array should be of the form key=value.
+// If env is an empty array, any exec commands will be run with an empty environment.
 func (p *Pipe) WithEnv(env []string) *Pipe {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/script.go
+++ b/script.go
@@ -911,10 +911,10 @@ func (p *Pipe) WithStdout(w io.Writer) *Pipe {
 	return p
 }
 
-// WithEnv sets the environment for the exec commands to the string array env.
-// This will override the default process environment variables when executing
-// commands run via [Pipe.Exec] or [Pipe.ExecForEach]. This will not affect the
-// environment outside of [Pipe.Exec] or [Pipe.ExecForEach].
+// WithEnv sets the environment for subsequent [Pipe.Exec] and [Pipe.ExecForEach] commands
+// to the string slice env. This will override the default process environment variables
+// when executing commands run via [Pipe.Exec] or [Pipe.ExecForEach]. This will not affect
+// the environment outside of [Pipe.Exec] or [Pipe.ExecForEach].
 func (p *Pipe) WithEnv(env []string) *Pipe {
 	p.env = env
 	return p

--- a/script.go
+++ b/script.go
@@ -911,9 +911,10 @@ func (p *Pipe) WithStdout(w io.Writer) *Pipe {
 	return p
 }
 
-// WithEnv sets the pipe's environment to the string array env. This will override
-// the default process environment variables when executing commands run via [Pipe.Exec]
-// or [Pipe.ExecForEach].
+// WithEnv sets the environment for the exec commands to the string array env.
+// This will override the default process environment variables when executing
+// commands run via [Pipe.Exec] or [Pipe.ExecForEach]. This will not affect the
+// environment outside of [Pipe.Exec] or [Pipe.ExecForEach].
 func (p *Pipe) WithEnv(env []string) *Pipe {
 	p.env = env
 	return p

--- a/script.go
+++ b/script.go
@@ -871,6 +871,15 @@ func (p *Pipe) Wait() {
 	}
 }
 
+// WithEnv sets the environment for subsequent [Pipe.Exec] and [Pipe.ExecForEach] commands
+// to the string slice env. This will override the default process environment variables
+// when executing commands run via [Pipe.Exec] or [Pipe.ExecForEach]. This will not affect
+// the environment outside of [Pipe.Exec] or [Pipe.ExecForEach].
+func (p *Pipe) WithEnv(env []string) *Pipe {
+	p.env = env
+	return p
+}
+
 // WithError sets the error err on the pipe.
 func (p *Pipe) WithError(err error) *Pipe {
 	p.SetError(err)
@@ -908,15 +917,6 @@ func (p *Pipe) WithStderr(w io.Writer) *Pipe {
 // default [os.Stdout].
 func (p *Pipe) WithStdout(w io.Writer) *Pipe {
 	p.stdout = w
-	return p
-}
-
-// WithEnv sets the environment for subsequent [Pipe.Exec] and [Pipe.ExecForEach] commands
-// to the string slice env. This will override the default process environment variables
-// when executing commands run via [Pipe.Exec] or [Pipe.ExecForEach]. This will not affect
-// the environment outside of [Pipe.Exec] or [Pipe.ExecForEach].
-func (p *Pipe) WithEnv(env []string) *Pipe {
-	p.env = env
 	return p
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -1802,7 +1802,7 @@ func TestWithEnv_SetEmptyEnvironment(t *testing.T) {
 	}
 }
 
-func TestWithoutEnv_FallsBackToDefaultEnvironment(t *testing.T) {
+func TestNotSettingEnvFallsBackToDefaultEnvironment(t *testing.T) {
 	t.Parallel()
 	buf := new(bytes.Buffer)
 

--- a/script_test.go
+++ b/script_test.go
@@ -1798,7 +1798,7 @@ func TestWithEnv_SetsGivenVariablesForSubsequentExec(t *testing.T) {
 	}
 	want := "ENV1=test1 ENV2=test2\n"
 	if got != want {
-		t.Errorf("want %v, got %v", want, got)
+		t.Errorf("want %q, got %q", want, got)
 	}
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -1782,32 +1782,16 @@ func TestWithEnv_UnsetsAllEnvVarsGivenEmptySlice(t *testing.T) {
 	}
 }
 
-func TestWithEnvChangesExecutionEnvironment(t *testing.T) {
+func TestWithEnv_SetsGivenVariablesForSubsequentExec(t *testing.T) {
 	t.Parallel()
 	env := []string{"ENV1=test1", "ENV2=test2"}
 
-	got, err := script.NewPipe().WithEnv(env).Exec("printenv").String()
+	got, err := script.NewPipe().WithEnv(env).Exec("sh -c 'echo ENV1=$ENV1 ENV2=$ENV2'").String()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want := "ENV1=test1\nENV2=test2\n"
-
-	if got != want {
-		t.Errorf("want %v, got %v", want, got)
-	}
-}
-
-func TestNotSettingEnvFallsBackToDefaultEnvironment(t *testing.T) {
-	t.Parallel()
-
-	got, err := script.NewPipe().Exec("printenv").String()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// not setting the environment should simply use the task's default environment
-	want := strings.Join(os.Environ(), "\n") + "\n"
+	want := "ENV1=test1 ENV2=test2\n"
 
 	if got != want {
 		t.Errorf("want %v, got %v", want, got)

--- a/script_test.go
+++ b/script_test.go
@@ -1770,15 +1770,26 @@ func TestWithStdout_SetsSpecifiedWriterAsStdout(t *testing.T) {
 
 func TestWithEnv_UnsetsAllEnvVarsGivenEmptySlice(t *testing.T) {
 	t.Parallel()
-	want := []string{}
-
-	output, err := script.NewPipe().WithEnv(want).Exec("printenv").String()
+	os.Setenv("ENV1", "test1")
+	t.Cleanup(func() { os.Unsetenv("ENV1") })
+	// test that ENV1 exists without setting the environment
+	got, err := script.NewPipe().Exec("sh -c 'echo ENV1=$ENV1'").String()
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if output != "" {
-		t.Errorf("want empty environment, got %q", output)
+	want := "ENV1=test1\n"
+	if got != want {
+		t.Errorf("want %v, got %v", want, got)
+	}
+	// test that ENV1 does not exist when WithEnv takes in an empty slice
+	env := []string{}
+	got, err = script.NewPipe().WithEnv(env).Exec("sh -c 'echo ENV1=$ENV1'").String()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = "ENV1=\n"
+	if got != want {
+		t.Errorf("want %v, got %v", want, got)
 	}
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -1796,14 +1796,11 @@ func TestWithEnv_UnsetsAllEnvVarsGivenEmptySlice(t *testing.T) {
 func TestWithEnv_SetsGivenVariablesForSubsequentExec(t *testing.T) {
 	t.Parallel()
 	env := []string{"ENV1=test1", "ENV2=test2"}
-
 	got, err := script.NewPipe().WithEnv(env).Exec("sh -c 'echo ENV1=$ENV1 ENV2=$ENV2'").String()
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	want := "ENV1=test1 ENV2=test2\n"
-
 	if got != want {
 		t.Errorf("want %v, got %v", want, got)
 	}

--- a/script_test.go
+++ b/script_test.go
@@ -1769,23 +1769,6 @@ func TestWithStdout_SetsSpecifiedWriterAsStdout(t *testing.T) {
 	}
 }
 
-func TestWithEnv_SetsSuppliedEnvironmentOnPipe(t *testing.T) {
-	t.Parallel()
-	buf := new(bytes.Buffer)
-	env := []string{"ENV1=test1", "ENV2=test2"}
-
-	_, err := script.NewPipe().WithStdout(buf).WithEnv(env).Exec("printenv").Stdout()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	got := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-
-	if !slices.Equal(got, env) {
-		t.Errorf("expected %v, got %v", env, got)
-	}
-}
-
 func TestWithEnv_SetEmptyEnvironment(t *testing.T) {
 	t.Parallel()
 	buf := new(bytes.Buffer)
@@ -1799,6 +1782,23 @@ func TestWithEnv_SetEmptyEnvironment(t *testing.T) {
 	if len(buf.String()) != 0 {
 		got := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
 		t.Errorf("expected 0 environment variables, got %d %v", len(got), got)
+	}
+}
+
+func TestWithEnv_SetMultipleEnvVars(t *testing.T) {
+	t.Parallel()
+	buf := new(bytes.Buffer)
+	env := []string{"ENV1=test1", "ENV2=test2"}
+
+	_, err := script.NewPipe().WithStdout(buf).WithEnv(env).Exec("printenv").Stdout()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+
+	if !slices.Equal(got, env) {
+		t.Errorf("expected %v, got %v", env, got)
 	}
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -1770,26 +1770,22 @@ func TestWithStdout_SetsSpecifiedWriterAsStdout(t *testing.T) {
 
 func TestWithEnv_UnsetsAllEnvVarsGivenEmptySlice(t *testing.T) {
 	t.Parallel()
-	os.Setenv("ENV1", "test1")
-	t.Cleanup(func() { os.Unsetenv("ENV1") })
-	// test that ENV1 exists without setting the environment
-	got, err := script.NewPipe().Exec("sh -c 'echo ENV1=$ENV1'").String()
+	p := script.NewPipe().WithEnv([]string{"ENV1=test1"}).Exec("sh -c 'echo ENV1=$ENV1'")
+	want := "ENV1=test1\n"
+	got, err := p.String()
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "ENV1=test1\n"
 	if got != want {
-		t.Errorf("want %v, got %v", want, got)
+		t.Fatalf("want %q, got %q", want, got)
 	}
-	// test that ENV1 does not exist when WithEnv takes in an empty slice
-	env := []string{}
-	got, err = script.NewPipe().WithEnv(env).Exec("sh -c 'echo ENV1=$ENV1'").String()
+	got, err = p.Echo("").WithEnv([]string{}).Exec("sh -c 'echo ENV1=$ENV1'").String()
 	if err != nil {
 		t.Fatal(err)
 	}
 	want = "ENV1=\n"
 	if got != want {
-		t.Errorf("want %v, got %v", want, got)
+		t.Errorf("want %q, got %q", want, got)
 	}
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -1782,7 +1782,7 @@ func TestWithEnv_UnsetsAllEnvVarsGivenEmptySlice(t *testing.T) {
 	}
 }
 
-func TestWithEnv_SetMultipleEnvVars(t *testing.T) {
+func TestWithEnvChangesExecutionEnvironment(t *testing.T) {
 	t.Parallel()
 	env := []string{"ENV1=test1", "ENV2=test2"}
 

--- a/script_test.go
+++ b/script_test.go
@@ -1769,7 +1769,7 @@ func TestWithStdout_SetsSpecifiedWriterAsStdout(t *testing.T) {
 	}
 }
 
-func TestWithEnvironment_SetsSuppliedEnvironmentOnPipe(t *testing.T) {
+func TestWithEnv_SetsSuppliedEnvironmentOnPipe(t *testing.T) {
 	t.Parallel()
 	buf := new(bytes.Buffer)
 	env := []string{"ENV1=test1", "ENV2=test2"}
@@ -1786,7 +1786,7 @@ func TestWithEnvironment_SetsSuppliedEnvironmentOnPipe(t *testing.T) {
 	}
 }
 
-func TestWithEnvironment_SetEmptyEnvironment(t *testing.T) {
+func TestWithEnv_SetEmptyEnvironment(t *testing.T) {
 	t.Parallel()
 	buf := new(bytes.Buffer)
 	env := []string{}
@@ -1802,7 +1802,7 @@ func TestWithEnvironment_SetEmptyEnvironment(t *testing.T) {
 	}
 }
 
-func TestWithoutEnvironment_FallsBackToDefaultEnvironment(t *testing.T) {
+func TestWithoutEnv_FallsBackToDefaultEnvironment(t *testing.T) {
 	t.Parallel()
 	buf := new(bytes.Buffer)
 

--- a/script_test.go
+++ b/script_test.go
@@ -1786,6 +1786,22 @@ func TestWithEnvironment_SetsSuppliedEnvironmentOnPipe(t *testing.T) {
 	}
 }
 
+func TestWithEnvironment_SetEmptyEnvironment(t *testing.T) {
+	t.Parallel()
+	buf := new(bytes.Buffer)
+	env := []string{}
+
+	_, err := script.NewPipe().WithStdout(buf).WithEnv(env).Exec("printenv").Stdout()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(buf.String()) != 0 {
+		got := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+		t.Errorf("expected 0 environment variables, got %d %v", len(got), got)
+	}
+}
+
 func TestWithoutEnvironment_FallsBackToDefaultEnvironment(t *testing.T) {
 	t.Parallel()
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
Added a method `WithEnv` that takes in a string array (`[]string `) and overrides the environment executing a `exec.Command` to that array. This PR fixes #80. 