### PR TITLE
fix(race-conditon): fix data race condition when accessing `stderr` on pipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v3
-      - run: go test ./...
+      - run: go test -race ./...
       
   gocritic:
     runs-on: ubuntu-latest

--- a/script.go
+++ b/script.go
@@ -387,7 +387,7 @@ func (p *Pipe) Exec(cmdLine string) *Pipe {
 		cmd.Stderr = w
 		pipeStderr := p.getStderr()
 		if pipeStderr != nil {
-			cmd.Stderr = p.stderr
+			cmd.Stderr = pipeStderr
 		}
 		err = cmd.Start()
 		if err != nil {
@@ -428,7 +428,7 @@ func (p *Pipe) ExecForEach(cmdLine string) *Pipe {
 			cmd.Stderr = w
 			pipeStderr := p.getStderr()
 			if pipeStderr != nil {
-				cmd.Stderr = p.stderr
+				cmd.Stderr = pipeStderr
 			}
 			err = cmd.Start()
 			if err != nil {

--- a/script.go
+++ b/script.go
@@ -27,13 +27,14 @@ import (
 // Pipe represents a pipe object with an associated [ReadAutoCloser].
 type Pipe struct {
 	// Reader is the underlying reader.
-	Reader         ReadAutoCloser
-	stdout, stderr io.Writer
-	httpClient     *http.Client
+	Reader     ReadAutoCloser
+	stdout     io.Writer
+	httpClient *http.Client
 
 	// because pipe stages are concurrent, protect 'err' and 'stderr'
-	mu  *sync.Mutex
-	err error
+	mu     *sync.Mutex
+	err    error
+	stderr io.Writer
 }
 
 // Args creates a pipe containing the program's command-line arguments from

--- a/script.go
+++ b/script.go
@@ -114,7 +114,7 @@ func Get(url string) *Pipe {
 
 // getStderr obtains the stderr writer on the pipe. This field
 // is protected by a mutex since stderr is accessed inside a
-// goroutine from [Pipe.Exec].
+// goroutine from [Pipe.Exec] and [Pipe.ExecForEach].
 func (p *Pipe) getStderr() io.Writer {
 	if p.mu == nil { // uninitialised pipe
 		return nil
@@ -808,7 +808,7 @@ func (p *Pipe) SetError(err error) {
 
 // setStderr sets the stderr writer on the pipe. This field
 // is protected by a mutex since stderr is accessed inside a
-// goroutine from [Pipe.Exec].
+// goroutine from [Pipe.Exec] and [Pipe.ExecForEach].
 func (p *Pipe) setStderr(stderr io.Writer) {
 	if p.mu == nil { // uninitialised pipe
 		return

--- a/script.go
+++ b/script.go
@@ -112,6 +112,18 @@ func Get(url string) *Pipe {
 	return NewPipe().Get(url)
 }
 
+// getStderr obtains the stderr writer on the pipe. This field
+// is protected by a mutex since stderr is accessed inside a
+// goroutine from [Pipe.Exec].
+func (p *Pipe) getStderr() io.Writer {
+	if p.mu == nil { // uninitialised pipe
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.stderr
+}
+
 // IfExists tests whether path exists, and creates a pipe whose error status
 // reflects the result. If the file doesn't exist, the pipe's error status will
 // be set, and if the file does exist, the pipe will have no error status. This
@@ -804,18 +816,6 @@ func (p *Pipe) setStderr(stderr io.Writer) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.stderr = stderr
-}
-
-// getStderr obtains the stderr writer on the pipe. This field
-// is protected by a mutex since stderr is accessed inside a
-// goroutine from [Pipe.Exec].
-func (p *Pipe) getStderr() io.Writer {
-	if p.mu == nil { // uninitialised pipe
-		return nil
-	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.stderr
 }
 
 // SHA256Sum returns the hex-encoded SHA-256 hash of the entire contents of the

--- a/script.go
+++ b/script.go
@@ -385,12 +385,10 @@ func (p *Pipe) Exec(cmdLine string) *Pipe {
 		cmd.Stdin = r
 		cmd.Stdout = w
 		cmd.Stderr = w
-
 		pipeStderr := p.getStderr()
 		if pipeStderr != nil {
 			cmd.Stderr = p.stderr
 		}
-
 		err = cmd.Start()
 		if err != nil {
 			fmt.Fprintln(cmd.Stderr, err)

--- a/script_test.go
+++ b/script_test.go
@@ -1971,14 +1971,9 @@ func TestEncodeBase64_CorrectlyEncodesInputBytes(t *testing.T) {
 	}
 }
 
-// TestWithStdErrAfterExec_DoesNotResultInRaceCondition is a regression test
-// that was added to test against a race condition for [Pipe.stderr].
-func TestWithStdErrAfterExec_DoesNotResultInRaceCondition(t *testing.T) {
+func TestWithStdErr_IsConcurrencySafeAfterExec(t *testing.T) {
 	t.Parallel()
-	stdOut := new(bytes.Buffer)
-	stdErr := new(bytes.Buffer)
-
-	_, err := script.Exec("echo").WithStdout(stdOut).WithStderr(stdErr).Stdout()
+	err := script.Exec("echo").WithStderr(nil).Wait()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/script_test.go
+++ b/script_test.go
@@ -1850,19 +1850,6 @@ func TestReadReturnsErrorGivenReadErrorOnPipe(t *testing.T) {
 	}
 }
 
-// TestWithStdErrAfterExec is a regression test that was added to test against
-// a race condition for Pipe.stderr.
-func TestWithStdErrAfterExec(t *testing.T) {
-	t.Parallel()
-	stdOut := new(bytes.Buffer)
-	stdErr := new(bytes.Buffer)
-
-	_, err := script.Exec("echo").WithStdout(stdOut).WithStderr(stdErr).Stdout()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestWait_ReturnsErrorPresentOnPipe(t *testing.T) {
 	t.Parallel()
 	p := script.Echo("a\nb\nc\n").ExecForEach("{{invalid template syntax}}")
@@ -1981,6 +1968,19 @@ func TestEncodeBase64_CorrectlyEncodesInputBytes(t *testing.T) {
 	if got != want {
 		t.Logf("input %#v incorrectly encoded:", input)
 		t.Error(cmp.Diff(want, got))
+	}
+}
+
+// TestWithStdErrAfterExec_DoesNotResultInRaceCondition is a regression test
+// that was added to test against a race condition for [Pipe.stderr].
+func TestWithStdErrAfterExec_DoesNotResultInRaceCondition(t *testing.T) {
+	t.Parallel()
+	stdOut := new(bytes.Buffer)
+	stdErr := new(bytes.Buffer)
+
+	_, err := script.Exec("echo").WithStdout(stdOut).WithStderr(stdErr).Stdout()
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -1861,6 +1861,7 @@ func TestWithStdErrAfterExec(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
 
 func TestWait_ReturnsErrorPresentOnPipe(t *testing.T) {
 	t.Parallel()

--- a/script_test.go
+++ b/script_test.go
@@ -1850,6 +1850,19 @@ func TestReadReturnsErrorGivenReadErrorOnPipe(t *testing.T) {
 	}
 }
 
+// TestWithStdErrAfterExec is a regression test that was added to test against
+// a race condition for Pipe.stderr.
+func TestWithStdErrAfterExec(t *testing.T) {
+	t.Parallel()
+	stdOut := new(bytes.Buffer)
+	stdErr := new(bytes.Buffer)
+
+	_, err := script.Exec("echo").WithStdout(stdOut).WithStderr(stdErr).Stdout()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func ExampleArgs() {
 	script.Args().Stdout()
 	// prints command-line arguments


### PR DESCRIPTION
There was a race condition that existed in `Pipe.Exec`, which spins up a goroutine that access `Pipe.stderr` without a lock. This PR fixes that by protecting `Pipe.stderr` with `Pipe.mu`. This PR fixes #193. 

**Testing**
Created a simple unit test as follows: 
```go
func TestDataRaceStdErr(t *testing.T) {
	stdOut := new(bytes.Buffer)
	stdErr := new(bytes.Buffer)

	_, err := script.Exec("echo").WithStdout(stdOut).WithStderr(stdErr).Stdout()
	if err != nil {
		t.Fatal(err)
	}
}
```
Running `go test -race` before the changes in this PR outputted the same warning seen in the issue. Running it again with the changes in the PR cause the tests to pass. 