### PR TITLE
refactor: return error on pipe from `Wait` method after completion of pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,7 @@ Sinks are methods that return some data from a pipe, ending the pipeline and ext
 | [`Slice`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Slice) | | data as `[]string`, error  |
 | [`Stdout`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Stdout) | standard output | bytes written, error  |
 | [`String`](https://pkg.go.dev/github.com/bitfield/script#Pipe.String) | | data as `string`, error  |
-| [`Wait`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Wait) | | none  |
-| [`WaitError`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WaitError) | | error  |
+| [`Wait`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Wait) | | error  |
 | [`WriteFile`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WriteFile) | specified file, truncating if it exists | bytes written, error  |
 
 # What's new

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Sinks are methods that return some data from a pipe, ending the pipeline and ext
 | [`Stdout`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Stdout) | standard output | bytes written, error  |
 | [`String`](https://pkg.go.dev/github.com/bitfield/script#Pipe.String) | | data as `string`, error  |
 | [`Wait`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Wait) | | none  |
+| [`WaitError`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WaitError) | | error  |
 | [`WriteFile`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WriteFile) | specified file, truncating if it exists | bytes written, error  |
 
 # What's new

--- a/script.go
+++ b/script.go
@@ -858,6 +858,14 @@ func (p *Pipe) Wait() {
 	}
 }
 
+// WaitError reads the pipe to completion and returns any error present on
+// the pipe, or nil otherwise. This is mostly useful for waiting until
+// concurrent filters have completed (see [Pipe.Filter]).
+func (p *Pipe) WaitError() error {
+	p.Wait()
+	return p.Error()
+}
+
 // WithError sets the error err on the pipe.
 func (p *Pipe) WithError(err error) *Pipe {
 	p.SetError(err)

--- a/script.go
+++ b/script.go
@@ -859,7 +859,6 @@ func (p *Pipe) Wait() error {
 	if err != nil {
 		p.SetError(err)
 	}
-
 	return p.Error()
 }
 

--- a/script.go
+++ b/script.go
@@ -348,6 +348,9 @@ func (p *Pipe) Echo(s string) *Pipe {
 }
 
 // Error returns any error present on the pipe, or nil otherwise.
+// Error is not a sink and does not wait until the pipe reaches
+// completion. To wait for completion before returning the error,
+// see [Pipe.WaitError].
 func (p *Pipe) Error() error {
 	if p.mu == nil { // uninitialised pipe
 		return nil

--- a/script.go
+++ b/script.go
@@ -350,7 +350,7 @@ func (p *Pipe) Echo(s string) *Pipe {
 // Error returns any error present on the pipe, or nil otherwise.
 // Error is not a sink and does not wait until the pipe reaches
 // completion. To wait for completion before returning the error,
-// see [Pipe.WaitError].
+// see [Pipe.Wait].
 func (p *Pipe) Error() error {
 	if p.mu == nil { // uninitialised pipe
 		return nil
@@ -851,21 +851,15 @@ func (p *Pipe) Tee(writers ...io.Writer) *Pipe {
 	return p.WithReader(io.TeeReader(p.Reader, teeWriter))
 }
 
-// Wait reads the pipe to completion and discards the result. This is mostly
-// useful for waiting until concurrent filters have completed (see
-// [Pipe.Filter]).
-func (p *Pipe) Wait() {
+// Wait reads the pipe to completion and returns any error present on
+// the pipe, or nil otherwise. This is mostly useful for waiting until
+// concurrent filters have completed (see [Pipe.Filter]).
+func (p *Pipe) Wait() error {
 	_, err := io.Copy(io.Discard, p)
 	if err != nil {
 		p.SetError(err)
 	}
-}
 
-// WaitError reads the pipe to completion and returns any error present on
-// the pipe, or nil otherwise. This is mostly useful for waiting until
-// concurrent filters have completed (see [Pipe.Filter]).
-func (p *Pipe) WaitError() error {
-	p.Wait()
 	return p.Error()
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -1864,6 +1864,7 @@ func TestWaitForNoErrorOnPipe(t *testing.T) {
 	if err := p.Wait(); err != nil {
 		t.Fatal(err)
 	}
+}
 
 var base64Cases = []struct {
 	name    string

--- a/script_test.go
+++ b/script_test.go
@@ -1850,6 +1850,22 @@ func TestReadReturnsErrorGivenReadErrorOnPipe(t *testing.T) {
 	}
 }
 
+func TestWaitErrorForErrorOnPipe(t *testing.T) {
+	t.Parallel()
+	p := script.Echo("a\nb\nc\n").ExecForEach("{{invalid template syntax}}")
+	if p.WaitError() == nil {
+		t.Error("want error, got nil")
+	}
+}
+
+func TestWaitErrorForNoErrorOnPipe(t *testing.T) {
+	t.Parallel()
+	p := script.Echo("a\nb\nc\n").ExecForEach("echo \"{{.}}\"")
+	if err := p.WaitError(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func ExampleArgs() {
 	script.Args().Stdout()
 	// prints command-line arguments

--- a/script_test.go
+++ b/script_test.go
@@ -1850,7 +1850,7 @@ func TestReadReturnsErrorGivenReadErrorOnPipe(t *testing.T) {
 	}
 }
 
-func TestWaitForErrorOnPipe(t *testing.T) {
+func TestWait_ReturnsErrorPresentOnPipe(t *testing.T) {
 	t.Parallel()
 	p := script.Echo("a\nb\nc\n").ExecForEach("{{invalid template syntax}}")
 	if p.Wait() == nil {
@@ -1858,7 +1858,7 @@ func TestWaitForErrorOnPipe(t *testing.T) {
 	}
 }
 
-func TestWaitForNoErrorOnPipe(t *testing.T) {
+func TestWait_DoesNotReturnErrorForValidExecution(t *testing.T) {
 	t.Parallel()
 	p := script.Echo("a\nb\nc\n").ExecForEach("echo \"{{.}}\"")
 	if err := p.Wait(); err != nil {

--- a/script_test.go
+++ b/script_test.go
@@ -1850,18 +1850,18 @@ func TestReadReturnsErrorGivenReadErrorOnPipe(t *testing.T) {
 	}
 }
 
-func TestWaitErrorForErrorOnPipe(t *testing.T) {
+func TestWaitForErrorOnPipe(t *testing.T) {
 	t.Parallel()
 	p := script.Echo("a\nb\nc\n").ExecForEach("{{invalid template syntax}}")
-	if p.WaitError() == nil {
+	if p.Wait() == nil {
 		t.Error("want error, got nil")
 	}
 }
 
-func TestWaitErrorForNoErrorOnPipe(t *testing.T) {
+func TestWaitForNoErrorOnPipe(t *testing.T) {
 	t.Parallel()
 	p := script.Echo("a\nb\nc\n").ExecForEach("echo \"{{.}}\"")
-	if err := p.WaitError(); err != nil {
+	if err := p.Wait(); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Updated the `Wait` method to return the error present on the pipe after completion. This PR closes #123. 