### PR TITLE
[fix] change behaviour of `FindFiles` to ignore errors 

### DIFF
--- a/script.go
+++ b/script.go
@@ -95,6 +95,9 @@ func FindFiles(dir string) *Pipe {
 	var paths []string
 	err := fs.WalkDir(os.DirFS(dir), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
+			if os.IsPermission(err) {
+				return fs.SkipDir
+			}
 			return err
 		}
 		if !d.IsDir() {

--- a/script.go
+++ b/script.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"io/fs"
 	"math"
 	"net/http"
 	"os"
@@ -92,12 +93,12 @@ func File(path string) *Pipe {
 //	test/2.txt
 func FindFiles(dir string) *Pipe {
 	var paths []string
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err := fs.WalkDir(os.DirFS(dir), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !info.IsDir() {
-			paths = append(paths, path)
+		if !d.IsDir() {
+			paths = append(paths, filepath.Join(dir, path))
 		}
 		return nil
 	})

--- a/script.go
+++ b/script.go
@@ -93,20 +93,19 @@ func File(path string) *Pipe {
 //	test/2.txt
 func FindFiles(dir string) *Pipe {
 	var paths []string
-	err := fs.WalkDir(os.DirFS(dir), ".", func(path string, d fs.DirEntry, err error) error {
+	var innerErr error
+	fs.WalkDir(os.DirFS(dir), ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			if os.IsPermission(err) {
-				return fs.SkipDir
-			}
-			return err
+			innerErr = err
+			return fs.SkipDir
 		}
 		if !d.IsDir() {
 			paths = append(paths, filepath.Join(dir, path))
 		}
 		return nil
 	})
-	if err != nil && len(paths) == 0 {
-		return NewPipe().WithError(err)
+	if innerErr != nil && len(paths) == 0 {
+		return NewPipe().WithError(innerErr)
 	}
 	return Slice(paths)
 }

--- a/script.go
+++ b/script.go
@@ -77,8 +77,12 @@ func File(path string) *Pipe {
 }
 
 // FindFiles creates a pipe listing all the files in the directory dir and its
-// subdirectories recursively, one per line, like Unix find(1). If dir doesn't
-// exist or can't be read, the pipe's error status will be set.
+// subdirectories recursively, one per line, like Unix find(1).
+// If an error occurs while reading the directory, the behaviour is as follows:
+//   - If no files have been found (the directory is empty or inaccessible), the
+//     resulting Pipe will have its error status set to the encountered error.
+//   - If at least one file is found, the error is ignored, and the resulting Pipe will
+//     contain the successfully found file paths.
 //
 // Each line of the output consists of a slash-separated path, starting with
 // the initial directory. For example, if the directory looks like this:

--- a/script.go
+++ b/script.go
@@ -102,7 +102,7 @@ func FindFiles(dir string) *Pipe {
 		}
 		return nil
 	})
-	if err != nil {
+	if err != nil && len(paths) == 0 {
 		return NewPipe().WithError(err)
 	}
 	return Slice(paths)

--- a/script.go
+++ b/script.go
@@ -78,11 +78,8 @@ func File(path string) *Pipe {
 
 // FindFiles creates a pipe listing all the files in the directory dir and its
 // subdirectories recursively, one per line, like Unix find(1).
-// If an error occurs while reading the directory, the behaviour is as follows:
-//   - If no files have been found (the directory is empty or inaccessible), the
-//     resulting Pipe will have its error status set to the encountered error.
-//   - If at least one file is found, the error is ignored, and the resulting Pipe will
-//     contain the successfully found file paths.
+// Errors are ignored unless no files are found (in which case the pipe's error
+// status will be set to the last error encountered).
 //
 // Each line of the output consists of a slash-separated path, starting with
 // the initial directory. For example, if the directory looks like this:

--- a/script_test.go
+++ b/script_test.go
@@ -1286,39 +1286,6 @@ func TestFindFiles_InNonexistentPathReturnsError(t *testing.T) {
 	}
 }
 
-func TestFindFiles_DoesNotErrorWhenSubDirectoryIsNotReadable(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
-	fileAPath := filepath.Join(tmpDir, "file_a.txt")
-	if err := os.WriteFile(fileAPath, []byte("hello world!"), os.ModePerm); err != nil {
-		t.Fatal(err)
-	}
-	restrictedDirPath := filepath.Join(tmpDir, "restricted_dir")
-	if err := os.Mkdir(restrictedDirPath, os.ModePerm); err != nil {
-		t.Fatal(err)
-	}
-	fileBPath := filepath.Join(restrictedDirPath, "file_b.txt")
-	if err := os.WriteFile(fileBPath, []byte("hello again!"), os.ModePerm); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chmod(restrictedDirPath, 0o000); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.Chmod(restrictedDirPath, os.ModePerm) })
-	p := script.FindFiles(tmpDir)
-	if p.Error() != nil {
-		t.Fatal(p.Error())
-	}
-	want := fileAPath + "\n"
-	got, err := p.String()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !cmp.Equal(want, got) {
-		t.Fatal(cmp.Diff(want, got))
-	}
-}
-
 func TestIfExists_ProducesErrorPlusNoOutputForNonexistentFile(t *testing.T) {
 	t.Parallel()
 	want := ""

--- a/script_unix_test.go
+++ b/script_unix_test.go
@@ -112,26 +112,18 @@ func TestFindFiles_DoesNotErrorWhenSubDirectoryIsNotReadable(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	restrictedDirPath := filepath.Join(tmpDir, "a_restricted_dir")
-	if err := os.Mkdir(restrictedDirPath, os.ModePerm); err != nil {
+	if err := os.Mkdir(restrictedDirPath, 0o000); err != nil {
 		t.Fatal(err)
 	}
-	fileAPath := filepath.Join(restrictedDirPath, "file_a.txt")
-	if err := os.WriteFile(fileAPath, []byte("hello again!"), os.ModePerm); err != nil {
+	fileAPath := filepath.Join(tmpDir, "file_a.txt")
+	if err := os.WriteFile(fileAPath, []byte("hello world!"), os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
-	fileBPath := filepath.Join(tmpDir, "file_b.txt")
-	if err := os.WriteFile(fileBPath, []byte("hello world!"), os.ModePerm); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chmod(restrictedDirPath, 0o000); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.Chmod(restrictedDirPath, os.ModePerm) })
 	got, err := script.FindFiles(tmpDir).String()
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := fileBPath + "\n"
+	want := fileAPath + "\n"
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/script_unix_test.go
+++ b/script_unix_test.go
@@ -111,16 +111,16 @@ func TestExecPipesDataToExternalCommandAndGetsExpectedOutput(t *testing.T) {
 func TestFindFiles_DoesNotErrorWhenSubDirectoryIsNotReadable(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	fileAPath := filepath.Join(tmpDir, "file_a.txt")
-	if err := os.WriteFile(fileAPath, []byte("hello world!"), os.ModePerm); err != nil {
-		t.Fatal(err)
-	}
-	restrictedDirPath := filepath.Join(tmpDir, "restricted_dir")
+	restrictedDirPath := filepath.Join(tmpDir, "a_restricted_dir")
 	if err := os.Mkdir(restrictedDirPath, os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
-	fileBPath := filepath.Join(restrictedDirPath, "file_b.txt")
-	if err := os.WriteFile(fileBPath, []byte("hello again!"), os.ModePerm); err != nil {
+	fileAPath := filepath.Join(restrictedDirPath, "file_a.txt")
+	if err := os.WriteFile(fileAPath, []byte("hello again!"), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	fileBPath := filepath.Join(tmpDir, "file_b.txt")
+	if err := os.WriteFile(fileBPath, []byte("hello world!"), os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Chmod(restrictedDirPath, 0o000); err != nil {
@@ -131,7 +131,7 @@ func TestFindFiles_DoesNotErrorWhenSubDirectoryIsNotReadable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := fileAPath + "\n"
+	want := fileBPath + "\n"
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Replaced `filepath.Walk` with the newer `fs.WalkDir`
- Changed the behaviour of `FindFiles` to only return an error if no paths were found
- Fixes #99  