### PR TITLE
Implemented `MatchRegexpWithLineNumber()` and `MatchWithLineNumber()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Filters are methods on an existing pipe that also return a pipe, allowing you to
 | [`SHA256Sums`](https://pkg.go.dev/github.com/bitfield/script#Pipe.SHA256Sums) | SHA-256 hashes of each listed file |
 | [`Tee`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Tee) | input copied to supplied writers |
 
-Note that filters run concurrently, rather than producing nothing until each stage has fully read its input. This is convenient for executing long-running comands, for example. If you do need to wait for the pipeline to complete, call [`Wait`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Wait).
+Note that filters run concurrently, rather than producing nothing until each stage has fully read its input. This is convenient for executing long-running commands, for example. If you do need to wait for the pipeline to complete, call [`Wait`](https://pkg.go.dev/github.com/bitfield/script#Pipe.Wait).
 
 ## Sinks
 


### PR DESCRIPTION
These behave as `grep -n` does: output the matched line prefixed by the line number.

**Simple test:**

> /tmp/test.txt
```
Sample data:
This is a test of MatchRegexpWithLineNumber() and MatchWithLineNumber()
They behave as the `grep -n` would
MatchRegexpWithLineNumber() will also find this TEST occurrence because it's case-insensitive
```

code:
```go
func main() {
        filePath := "/tmp/test.txt"
        pattern := "test"
        str, _ := script.File(filePath).MatchWithLineNumber(pattern).First(3).String()
        fmt.Printf("Testing MatchWithLineNumber with %s...\noutput is:\n%s\n", pattern, str)
        r := regexp.MustCompile("(?i)" + regexp.QuoteMeta(pattern))
        str, _ = script.File(filePath).MatchRegexpWithLineNumber(r).String()
        fmt.Printf("Testing MatchRegexpWithLineNumber with %s...\noutput is:\n%s\n", pattern, str)
}

```

Output:
```
Testing MatchWithLineNumber with test...
output is:
2:This is a test of MatchRegexpWithLineNumber() and MatchWithLineNumber()

Testing MatchRegexpWithLineNumber with test...
output is:
2:This is a test of MatchRegexpWithLineNumber() and MatchWithLineNumber()
4:MatchRegexpWithLineNumber() will also find this TEST occurrence because it's case-insensitive
```