### PR TITLE
Change JQ to process newline-delimited JSON

### DIFF
--- a/script_test.go
+++ b/script_test.go
@@ -845,11 +845,11 @@ func TestJQErrorsWithInvalidInput(t *testing.T) {
 
 func TestJQProducesValidResultsUntilFirstError(t *testing.T) {
 	t.Parallel()
-	input := "[1]\ninvalid JSON value"
+	input := "[1]\ninvalid JSON value\n[2]"
 	want := "1\n"
 	got, err := script.Echo(input).JQ(".[0]").String()
 	if err == nil {
-		t.Fatal("want error from invalid JSON input, got nil")
+		t.Error("want error from invalid JSON input, got nil")
 	}
 	if want != got {
 		t.Error(cmp.Diff(want, got))

--- a/script_test.go
+++ b/script_test.go
@@ -743,7 +743,6 @@ func TestJQWithDotQueryPrettyPrintsInput(t *testing.T) {
 		t.Fatal(err)
 	}
 	if want != got {
-		t.Error(want, got)
 		t.Error(cmp.Diff(want, got))
 	}
 }
@@ -757,7 +756,6 @@ func TestJQWithFieldQueryProducesSelectedField(t *testing.T) {
 		t.Fatal(err)
 	}
 	if want != got {
-		t.Error(want, got)
 		t.Error(cmp.Diff(want, got))
 	}
 }
@@ -771,7 +769,6 @@ func TestJQWithArrayQueryProducesRequiredArray(t *testing.T) {
 		t.Fatal(err)
 	}
 	if want != got {
-		t.Error(want, got)
 		t.Error(cmp.Diff(want, got))
 	}
 }
@@ -785,7 +782,6 @@ func TestJQWithArrayInputAndElementQueryProducesSelectedElement(t *testing.T) {
 		t.Fatal(err)
 	}
 	if want != got {
-		t.Error(want, got)
 		t.Error(cmp.Diff(want, got))
 	}
 }
@@ -799,7 +795,6 @@ func TestJQHandlesGithubJSONWithRealWorldExampleQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	if want != got {
-		t.Error(want, got)
 		t.Error(cmp.Diff(want, got))
 	}
 }


### PR DESCRIPTION
Update `JQ` filter to handle [newline-delimited JSON (NDJSON)](https://jsonlines.org).

Fixes https://github.com/bitfield/script/issues/226.

## Implementation Notes

- Used decoder's `More()` method for cleaner iteration over JSON stream
- Preserved existing code style with short variable names
- Preserved error handling approach with early returns
- Preserves `interface{}` usage instead of `any`
- No return value checks for `fmt.Fprintln`
- Direct return of external package errors without wrapping
- Wrote individual tests instead of table driven tests

## Example

Analyzes logs to count and display frequency of different log levels from newline-delimited JSON input.

```
cat log.json | ./goscript.sh -c 'script.Stdin().JQ(".level").Freq().Stdout()'
3 "INFO"
2 "WARN"
1 "ERROR"
```