### PR TITLE
Add timeout support for Exec and ExecForEach commands (fixes #225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ script.Exec("ping 127.0.0.1").Stdout()
 
 Note that `Exec` runs the command concurrently: it doesn't wait for the command to complete before returning any output. That's good, because this `ping` command will run forever (or until we get bored).
 
+If you need to prevent a command from running indefinitely, you can set a timeout:
+
+```go
+script.NewPipe().WithTimeout(5*time.Second).Exec("potentially-hanging-command").Wait()
+```
+
+If the command doesn't complete within the timeout, it will be terminated and an error will be set.
+
 Instead, when we read from the pipe using `Stdout`, we see each line of output as it's produced:
 
 ```
@@ -328,6 +336,7 @@ These are methods on a pipe that change its configuration:
 | [`WithReader`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithReader) | pipe source |
 | [`WithStderr`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStderr) | standard error output stream for command |
 | [`WithStdout`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStdout) | standard output stream for pipe |
+| [`WithTimeout`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithTimeout) | timeout for exec commands |
 
 ## Filters
 


### PR DESCRIPTION
## Problem

`Exec` and `ExecForEach` commands can run indefinitely, causing resource leaks and hanging CI/CD pipelines with no way to set timeouts.

## Solution

Adds `WithTimeout(duration time.Duration)` method for both `Exec` and `ExecForEach` commands.

```go
// Basic usage
script.NewPipe().WithTimeout(5*time.Second).Exec("sleep 10").Wait()

// ExecForEach with timeout
script.Echo("file1\nfile2").WithTimeout(2*time.Second).ExecForEach("sleep 5").Wait()
```

## Realistic Example: CI/CD Pipeline
```go
// Build with timeout
script.Exec("go build ./...").WithTimeout(2*time.Minute).Wait()

// Test with timeout  
script.Exec("go test ./...").WithTimeout(5*time.Minute).Wait()

// Security scan with timeout
script.Exec("gosec ./...").WithTimeout(1*time.Minute).Wait()
```

## Why This is Better

- **Simple API**: `WithTimeout()` follows existing patterns
- **No external deps**: Built into the library
- **Reliable**: Uses `context.WithTimeout` and `exec.CommandContext`
- **Backward compatible**: Zero timeout means no timeout

Fixes #225