### PR TITLE
pass optional context to pipe (#225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ These are methods on a pipe that change its configuration:
 | [`WithReader`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithReader) | pipe source |
 | [`WithStderr`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStderr) | standard error output stream for command |
 | [`WithStdout`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStdout) | standard output stream for pipe |
+| [`WithContext`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithContext) | context used in
+exec and http requests |
 
 ## Filters
 

--- a/README.md
+++ b/README.md
@@ -322,13 +322,13 @@ These are methods on a pipe that change its configuration:
 
 | Source | Modifies |
 | -------- | ------------- |
+| [`WithContext`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithContext) | context used in
 | [`WithEnv`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithEnv) | environment for commands |
 | [`WithError`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithError) | pipe error status |
 | [`WithHTTPClient`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithHTTPClient) | client for HTTP requests |
 | [`WithReader`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithReader) | pipe source |
 | [`WithStderr`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStderr) | standard error output stream for command |
 | [`WithStdout`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStdout) | standard output stream for pipe |
-| [`WithContext`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithContext) | context used in
 exec and http requests |
 
 ## Filters

--- a/README.md
+++ b/README.md
@@ -322,14 +322,13 @@ These are methods on a pipe that change its configuration:
 
 | Source | Modifies |
 | -------- | ------------- |
-| [`WithContext`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithContext) | context used in
+| [`WithContext`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithContext) | context used in commands or HTTP requests |
 | [`WithEnv`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithEnv) | environment for commands |
 | [`WithError`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithError) | pipe error status |
 | [`WithHTTPClient`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithHTTPClient) | client for HTTP requests |
 | [`WithReader`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithReader) | pipe source |
 | [`WithStderr`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStderr) | standard error output stream for command |
 | [`WithStdout`](https://pkg.go.dev/github.com/bitfield/script#Pipe.WithStdout) | standard output stream for pipe |
-exec and http requests |
 
 ## Filters
 

--- a/script.go
+++ b/script.go
@@ -3,6 +3,7 @@ package script
 import (
 	"bufio"
 	"container/ring"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -38,6 +39,7 @@ type Pipe struct {
 	err    error
 	stderr io.Writer
 	env    []string
+	ctx    context.Context
 }
 
 // Args creates a pipe containing the program's command-line arguments from
@@ -174,6 +176,7 @@ func NewPipe() *Pipe {
 		stdout:     os.Stdout,
 		httpClient: http.DefaultClient,
 		env:        nil,
+		ctx:        context.Background(),
 	}
 }
 
@@ -432,7 +435,7 @@ func (p *Pipe) Exec(cmdLine string) *Pipe {
 		if err != nil {
 			return err
 		}
-		cmd := exec.Command(args[0], args[1:]...)
+		cmd := exec.CommandContext(p.ctx, args[0], args[1:]...)
 		cmd.Stdin = r
 		cmd.Stdout = w
 		cmd.Stderr = w
@@ -470,6 +473,9 @@ func (p *Pipe) ExecForEach(cmdLine string) *Pipe {
 	return p.Filter(func(r io.Reader, w io.Writer) error {
 		scanner := newScanner(r)
 		for scanner.Scan() {
+			if p.ctx.Err() != nil {
+				return p.ctx.Err()
+			}
 			cmdLine := new(strings.Builder)
 			err := tpl.Execute(cmdLine, scanner.Text())
 			if err != nil {
@@ -479,7 +485,7 @@ func (p *Pipe) ExecForEach(cmdLine string) *Pipe {
 			if err != nil {
 				return err
 			}
-			cmd := exec.Command(args[0], args[1:]...)
+			cmd := exec.CommandContext(p.ctx, args[0], args[1:]...)
 			cmd.Stdout = w
 			cmd.Stderr = w
 			pipeStderr := p.stdErr()
@@ -652,7 +658,7 @@ func (p *Pipe) Freq() *Pipe {
 // the request body, and produces the server's response. See [Pipe.Do] for how
 // the HTTP response status is interpreted.
 func (p *Pipe) Get(url string) *Pipe {
-	req, err := http.NewRequest(http.MethodGet, url, p.Reader)
+	req, err := http.NewRequestWithContext(p.ctx, http.MethodGet, url, p.Reader)
 	if err != nil {
 		return p.WithError(err)
 	}
@@ -807,7 +813,7 @@ func (p *Pipe) MatchRegexp(re *regexp.Regexp) *Pipe {
 // the request body, and produces the server's response. See [Pipe.Do] for how
 // the HTTP response status is interpreted.
 func (p *Pipe) Post(url string) *Pipe {
-	req, err := http.NewRequest(http.MethodPost, url, p.Reader)
+	req, err := http.NewRequestWithContext(p.ctx, http.MethodPost, url, p.Reader)
 	if err != nil {
 		return p.WithError(err)
 	}
@@ -1012,6 +1018,16 @@ func (p *Pipe) WithStderr(w io.Writer) *Pipe {
 func (p *Pipe) WithStdout(w io.Writer) *Pipe {
 	p.stdout = w
 	return p
+}
+
+// WithContext sets the context for subsequent [Pipe.Exec], [Pipe.ExecForEach], [Pipe.Get] and [Pipe.Post] commands .
+func (p *Pipe) WithContext(ctx context.Context) *Pipe {
+	p.ctx = ctx
+	return p
+}
+
+func WithContext(ctx context.Context) *Pipe {
+	return NewPipe().WithContext(ctx)
 }
 
 // WriteFile writes the pipe's contents to the file path, truncating it if it

--- a/script.go
+++ b/script.go
@@ -201,6 +201,11 @@ func Stdin() *Pipe {
 	return NewPipe().WithReader(os.Stdin)
 }
 
+// WithContext creates a pipe with the context ctx.
+func WithContext(ctx context.Context) *Pipe {
+	return NewPipe().WithContext(ctx)
+}
+
 // AppendFile appends the contents of the pipe to the file path, creating it if
 // necessary, and returns the number of bytes successfully written, or an
 // error.
@@ -329,6 +334,12 @@ func (p *Pipe) Dirname() *Pipe {
 // set by [Pipe.WithHTTPClient], or [http.DefaultClient] otherwise. The
 // response body is streamed concurrently to the pipe's output. If the response
 // status is anything other than HTTP 200-299, the pipe's error status is set.
+//
+// # Context
+//
+// The request does not inherit the pipe's context (if any was set by
+// [Pipe.WithContext]). If you want the request to be cancellable, you will need to set
+// your own context on it.
 func (p *Pipe) Do(req *http.Request) *Pipe {
 	return p.Filter(func(r io.Reader, w io.Writer) error {
 		resp, err := p.httpClient.Do(req)
@@ -416,6 +427,11 @@ func (p *Pipe) Error() error {
 // The command inherits the current process's environment, optionally modified
 // by [Pipe.WithEnv].
 //
+// # Context
+//
+// The command inherits the pipe's context (if any was set by [Pipe.WithContext]), and
+// will be cancelled if the context is cancelled or times out.
+//
 // # Error handling
 //
 // If the command had a non-zero exit status, the pipe's error status will also
@@ -465,6 +481,16 @@ func (p *Pipe) Exec(cmdLine string) *Pipe {
 // syntax. For example:
 //
 //	ListFiles("*").ExecForEach("touch {{.}}").Wait()
+//
+// # Environment
+//
+// The command inherits the current process's environment, optionally modified
+// by [Pipe.WithEnv].
+//
+// # Context
+//
+// The command inherits the pipe's context (if any was set by [Pipe.WithContext]), and
+// will be cancelled if the context is cancelled or times out.
 func (p *Pipe) ExecForEach(cmdLine string) *Pipe {
 	tpl, err := template.New("").Parse(cmdLine)
 	if err != nil {
@@ -536,9 +562,10 @@ func (p *Pipe) ExitStatus() int {
 // [io.Writer] to write its output to, and returns an error, which will be set
 // on the pipe.
 //
-// filter runs concurrently, so its goroutine will not exit until the pipe has
-// been fully read. Use [Pipe.Wait] to wait for all concurrent filters to
-// complete.
+// filter runs concurrently, so its goroutine will not exit until the pipe has been
+// fully read. Use [Pipe.Wait] to wait for all concurrent filters to complete. These
+// goroutines are not automatically cancelled by the pipe's context, if one was set by
+// [Pipe.WithContext].
 func (p *Pipe) Filter(filter func(io.Reader, io.Writer) error) *Pipe {
 	if p.Error() != nil {
 		return p
@@ -657,6 +684,11 @@ func (p *Pipe) Freq() *Pipe {
 // Get makes an HTTP GET request to url, sending the contents of the pipe as
 // the request body, and produces the server's response. See [Pipe.Do] for how
 // the HTTP response status is interpreted.
+//
+// # Context
+//
+// The request inherits the pipe's context (if any was set by [Pipe.WithContext]), and
+// will be cancelled if the context is cancelled or times out.
 func (p *Pipe) Get(url string) *Pipe {
 	req, err := http.NewRequestWithContext(p.ctx, http.MethodGet, url, p.Reader)
 	if err != nil {
@@ -812,6 +844,11 @@ func (p *Pipe) MatchRegexp(re *regexp.Regexp) *Pipe {
 // Post makes an HTTP POST request to url, using the contents of the pipe as
 // the request body, and produces the server's response. See [Pipe.Do] for how
 // the HTTP response status is interpreted.
+//
+// # Context
+//
+// The request inherits the pipe's context (if any was set by [Pipe.WithContext]), and
+// will be cancelled if the context is cancelled or times out.
 func (p *Pipe) Post(url string) *Pipe {
 	req, err := http.NewRequestWithContext(p.ctx, http.MethodPost, url, p.Reader)
 	if err != nil {
@@ -969,6 +1006,12 @@ func (p *Pipe) Wait() error {
 	return p.Error()
 }
 
+// WithContext sets the context for subsequent [Pipe.Exec], [Pipe.ExecForEach], [Pipe.Get] and [Pipe.Post] commands.
+func (p *Pipe) WithContext(ctx context.Context) *Pipe {
+	p.ctx = ctx
+	return p
+}
+
 // WithEnv sets the environment for subsequent [Pipe.Exec] and [Pipe.ExecForEach]
 // commands to the string slice env, using the same format as [os/exec.Cmd.Env].
 // An empty slice unsets all existing environment variables.
@@ -1018,16 +1061,6 @@ func (p *Pipe) WithStderr(w io.Writer) *Pipe {
 func (p *Pipe) WithStdout(w io.Writer) *Pipe {
 	p.stdout = w
 	return p
-}
-
-// WithContext sets the context for subsequent [Pipe.Exec], [Pipe.ExecForEach], [Pipe.Get] and [Pipe.Post] commands.
-func (p *Pipe) WithContext(ctx context.Context) *Pipe {
-	p.ctx = ctx
-	return p
-}
-
-func WithContext(ctx context.Context) *Pipe {
-	return NewPipe().WithContext(ctx)
 }
 
 // WriteFile writes the pipe's contents to the file path, truncating it if it

--- a/script.go
+++ b/script.go
@@ -1020,7 +1020,7 @@ func (p *Pipe) WithStdout(w io.Writer) *Pipe {
 	return p
 }
 
-// WithContext sets the context for subsequent [Pipe.Exec], [Pipe.ExecForEach], [Pipe.Get] and [Pipe.Post] commands .
+// WithContext sets the context for subsequent [Pipe.Exec], [Pipe.ExecForEach], [Pipe.Get] and [Pipe.Post] commands.
 func (p *Pipe) WithContext(ctx context.Context) *Pipe {
 	p.ctx = ctx
 	return p

--- a/script_test.go
+++ b/script_test.go
@@ -2167,6 +2167,7 @@ func TestHash_ReturnsErrorGivenReadErrorOnPipe(t *testing.T) {
 }
 
 func TestHashSums_OutputsEmptyStringForFileThatCannotBeHashed(t *testing.T) {
+	t.Parallel()
 	got, err := script.Echo("file_does_not_exist.txt").HashSums(sha256.New()).String()
 	if err != nil {
 		t.Fatal(err)
@@ -2177,42 +2178,52 @@ func TestHashSums_OutputsEmptyStringForFileThatCannotBeHashed(t *testing.T) {
 	}
 }
 
-func TestWithContext_CallCancelBeforeExec(t *testing.T) {
+func TestWithContext_SkipsExecWithCancelledContext(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	cancel()
-	err := script.NewPipe().WithContext(ctx).Exec("echo Hello, World").Wait()
+	output, err := script.WithContext(ctx).Exec("echo Hello, World").String()
 	if err == nil {
-		t.Fatal("expected error due to context cancellation, got nil")
+		t.Error("expected error due to context cancellation, got nil")
+	}
+	if strings.Contains(output, "Hello") {
+		t.Fatal("command ran even though context cancelled beforehand")
 	}
 }
 
-func TestWithContext_GetCanceledContext(t *testing.T) {
+func TestWithContext_SkipsGETRequestWithCancelledContext(t *testing.T) {
 	t.Parallel()
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	handler_called := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler_called = true
+	}))
 	defer ts.Close()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-
 	_, err := script.WithContext(ctx).Echo("request data").Get(ts.URL).String()
 	if err == nil {
-		t.Fatal("expected error from canceled context")
+		t.Fatal("expected error from cancelled context")
+	}
+	if handler_called {
+		t.Fatal("request made even though context cancelled beforehand")
 	}
 }
 
-func TestWithContext_PostCanceledContext(t *testing.T) {
+func TestWithContext_SkipsPOSTRequestWithCancelledContext(t *testing.T) {
 	t.Parallel()
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	handler_called := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler_called = true
+	}))
 	defer ts.Close()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-
 	_, err := script.WithContext(ctx).Echo("request data").Post(ts.URL).String()
 	if err == nil {
-		t.Fatal("expected error from canceled context")
+		t.Fatal("expected error from cancelled context")
+	}
+	if handler_called {
+		t.Fatal("request made even though context cancelled beforehand")
 	}
 }
 
@@ -2661,6 +2672,21 @@ func ExamplePipe_Tee_writers() {
 	// hello
 	// hello
 	// hello
+}
+
+func ExamplePipe_WithContext() {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(20 * time.Millisecond)
+	}))
+	defer ts.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := script.NewPipe().WithContext(ctx).Get(ts.URL).String()
+	if err != nil {
+		fmt.Println("cancelled")
+	}
+	// Output:
+	// cancelled
 }
 
 func ExamplePipe_WithStderr() {

--- a/script_test.go
+++ b/script_test.go
@@ -2177,103 +2177,42 @@ func TestHashSums_OutputsEmptyStringForFileThatCannotBeHashed(t *testing.T) {
 	}
 }
 
-func TestWithContext_CallTimeoutMidstream(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	err := script.WithContext(ctx).Exec("sleep 10").Wait()
-	if err == nil {
-		t.Fatal("expected error due to context cancellation, got nil")
-	}
-}
-
 func TestWithContext_CallCancelBeforeExec(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	cancel()
-	err := script.WithContext(ctx).Exec("echo Hello, World").Wait()
+	err := script.NewPipe().WithContext(ctx).Exec("echo Hello, World").Wait()
 	if err == nil {
 		t.Fatal("expected error due to context cancellation, got nil")
 	}
 }
 
-func TestWithContext_GetWithContextTimeout(t *testing.T) {
+func TestWithContext_GetCanceledContext(t *testing.T) {
 	t.Parallel()
-	tcs := []struct {
-		name    string
-		timeout time.Duration
-		expErr  bool
-	}{
-		{
-			name:    "timeout less than server response time",
-			timeout: 500 * time.Millisecond,
-			expErr:  true,
-		},
-		{
-			name:    "timeout greater than server response time",
-			timeout: 2 * time.Second,
-			expErr:  false,
-		},
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(1 * time.Second)
-	}))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer ts.Close()
 
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
-			defer cancel()
-			_, err := script.WithContext(ctx).Echo("request data").Get(ts.URL).String()
-			if tc.expErr {
-				if err == nil {
-					t.Fatalf("expected error due to context timeout, got nil")
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("expected no error, got %v", err)
-				}
-			}
-		})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := script.WithContext(ctx).Echo("request data").Get(ts.URL).String()
+	if err == nil {
+		t.Fatal("expected error from canceled context")
 	}
 }
 
-func TestWithContext_PostWithContextTimeout(t *testing.T) {
+func TestWithContext_PostCanceledContext(t *testing.T) {
 	t.Parallel()
-	tcs := []struct {
-		name    string
-		timeout time.Duration
-		expErr  bool
-	}{
-		{
-			name:    "timeout less than server response time",
-			timeout: 500 * time.Millisecond,
-			expErr:  true,
-		},
-		{
-			name:    "timeout greater than server response time",
-			timeout: 2 * time.Second,
-			expErr:  false,
-		},
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(1 * time.Second)
-	}))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer ts.Close()
 
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
-			defer cancel()
-			_, err := script.WithContext(ctx).Echo("request data").Post(ts.URL).String()
-			if tc.expErr {
-				if err == nil {
-					t.Fatalf("expected error due to context timeout, got nil")
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("expected no error, got %v", err)
-				}
-			}
-		})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := script.WithContext(ctx).Echo("request data").Post(ts.URL).String()
+	if err == nil {
+		t.Fatal("expected error from canceled context")
 	}
 }
 

--- a/script_test.go
+++ b/script_test.go
@@ -3,6 +3,7 @@ package script_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"crypto/sha512"
 	"errors"
@@ -18,6 +19,7 @@ import (
 	"strings"
 	"testing"
 	"testing/iotest"
+	"time"
 
 	"github.com/bitfield/script"
 	"github.com/google/go-cmp/cmp"
@@ -2172,6 +2174,106 @@ func TestHashSums_OutputsEmptyStringForFileThatCannotBeHashed(t *testing.T) {
 	want := ""
 	if got != want {
 		t.Errorf("want %q, got %q", want, got)
+	}
+}
+
+func TestWithContext_CallTimeoutMidstream(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	err := script.WithContext(ctx).Exec("sleep 10").Wait()
+	if err == nil {
+		t.Fatal("expected error due to context cancellation, got nil")
+	}
+}
+
+func TestWithContext_CallCancelBeforeExec(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	cancel()
+	err := script.WithContext(ctx).Exec("echo Hello, World").Wait()
+	if err == nil {
+		t.Fatal("expected error due to context cancellation, got nil")
+	}
+}
+
+func TestWithContext_GetWithContextTimeout(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		name    string
+		timeout time.Duration
+		expErr  bool
+	}{
+		{
+			name:    "timeout less than server response time",
+			timeout: 500 * time.Millisecond,
+			expErr:  true,
+		},
+		{
+			name:    "timeout greater than server response time",
+			timeout: 2 * time.Second,
+			expErr:  false,
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1 * time.Second)
+	}))
+	defer ts.Close()
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
+			defer cancel()
+			_, err := script.WithContext(ctx).Echo("request data").Get(ts.URL).String()
+			if tc.expErr {
+				if err == nil {
+					t.Fatalf("expected error due to context timeout, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestWithContext_PostWithContextTimeout(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		name    string
+		timeout time.Duration
+		expErr  bool
+	}{
+		{
+			name:    "timeout less than server response time",
+			timeout: 500 * time.Millisecond,
+			expErr:  true,
+		},
+		{
+			name:    "timeout greater than server response time",
+			timeout: 2 * time.Second,
+			expErr:  false,
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1 * time.Second)
+	}))
+	defer ts.Close()
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tc.timeout)
+			defer cancel()
+			_, err := script.WithContext(ctx).Echo("request data").Post(ts.URL).String()
+			if tc.expErr {
+				if err == nil {
+					t.Fatalf("expected error due to context timeout, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Following the discussion: https://github.com/bitfield/script/issues/225, I added a simple `WithContext` closure and function to support timeouts/cancellations/deadlines. This is a straightforward implementation as `exec.CommandContext` and `http.NewRequestWithContext` return an error when the signal is received and that is cascaded by the existing implementation. I encountered this gap while migrating some test-suite setup scripts to use this library, and thought this would be an easy addition. 

**1. Show that the lack of the feature is a significant problem for a significant number of users.**

Exec and ExecForEach are two of the most commonly used methods in the library. Any caller invoking an external command in a program that has a timeout or deadline requirement (a web server handler, a CI runner, a daemon, any program with a --timeout flag) cannot use script.Exec because there is no way to cancel it. It's a common pattern of having request scoped timeouts and an overall timeout.

**2. Propose a feature that addresses the problem in a satisfactory way.**

Add a single method `WithContext(ctx context.Context) *Pipe` . Store the context on the Pipe struct. Use it in Exec and ExecForEach via exec.CommandContext, and in Do/Get/Post via req.WithContext. Default to context.Background() in NewPipe() so no existing code changes behaviour.

**3. Include a runnable example program that shows how the proposed syntax or API would be used to solve the problem for a realistic use case.**

Honestly unsure what's expected here. The use case I have encountered was during a DB setup for a component testing suite, with a non deterministic rebalancing step that should be complete before proceeding. The code snippet is not runnable as is but should convey the issue encountered.

```
    ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
    defer cancel()

    // Start the database container. Without context this hangs if docker stalls.
    if err := script.NewPipe().WithContext(ctx).
        Exec("docker compose up -d database").Wait(); err != nil {
        return err
    }

    if err := script.Echo(`nodes=node1,node2`).WithContext(ctx).
        Post("<host>/controller/rebalance").Wait(); err != nil {
        return err
    }

    // Poll until rebalance is complete. Each Post call in the loop
    for {
        status, err := script.Echo(`{}`).WithContext(ctx).
            Post("<host>/rebalanceProgress").String()
        if err != nil {
            return err // should return if overall context is exceeded
        }
        time.Sleep(2 * time.Second)
    }

    if err := script.Echo(`user=app&roles=readwrite`).WithContext(ctx).
        Post("http://localhost:8091/settings/auth").Wait(); err != nil {
        return err
    }


```

If any step exceeds the overall deadline, ctx is cancelled, the subprocess is killed, and the error propagates through the pipe's error mechanism.

**4. Show that this is significantly better than any existing solution without the feature.**

The only existing solution is to not use script.Exec and use raw os/exec.Command instead or using `NewRequestWithContext` and `Do` which limits the API.
